### PR TITLE
refactor: Button 컴포넌트 불필요한 코드 외부로 이동

### DIFF
--- a/src/components/atomic/Button.jsx
+++ b/src/components/atomic/Button.jsx
@@ -1,6 +1,21 @@
 import { Link } from 'react-router-dom';
 import PropTypes from 'prop-types';
 
+const sizes = {
+  small: 'max-w-[110px] h-[55px] px-5 py-[18px]',
+  large: 'w-full h-[55px] px-[126px] py-2',
+};
+
+const types = {
+  primary: 'bg-blue text-white ',
+  secondary: 'bg-white text-blue ',
+  disabled: 'bg-gray-200 text-gray-400 cursor-not-allowed',
+  red: 'bg-white text-red',
+};
+
+const baseClasses =
+  'rounded-xl font-bold flex justify-center items-center shadow-light';
+
 const Button = ({
   text = '레이블',
   size = 'small',
@@ -9,20 +24,6 @@ const Button = ({
   to,
   ...props
 }) => {
-  const sizes = {
-    small: 'max-w-[110px] h-[55px] px-5 py-[18px]',
-    large: 'w-full h-[55px] px-[126px] py-2',
-  };
-
-  const types = {
-    primary: 'bg-blue text-white ',
-    secondary: 'bg-white text-blue ',
-    disabled: 'bg-gray-200 text-gray-400 cursor-not-allowed',
-    red: 'bg-white text-red',
-  };
-
-  const baseClasses =
-    'rounded-xl font-bold flex justify-center items-center shadow-light';
   let typeClasses = types[type];
   let sizeClasses = sizes[size];
   const combinedClasses = `${baseClasses} ${sizeClasses} ${typeClasses} ${className}`;


### PR DESCRIPTION
### 제목 : refactor: Button 컴포넌트 불필요한 코드 외부로 이동

### PR 유형

- [ ] 새로운 기능 추가
- [ ] 버그 수정
- [ ] CSS 등 사용자 UI 디자인 변경
- [ ] 코드에 영향을 주지 않는 변경사항(오타 수정, 탭 사이즈 변경, 변수명 변경)
- [x] 코드 리팩토링
- [ ] 주석 추가 및 수정
- [ ] 문서 수정
- [ ] 테스트 추가, 테스트 리팩토링
- [ ] 빌드 부분 혹은 패키지 매니저 수정
- [ ] 파일 혹은 폴더명 수정
- [ ] 파일 혹은 폴더 삭제

### PR 체크리스트

<!-- PR이 다음 요구 사항을 충족하는지 확인하세요. -->

- [x] 커밋 메시지 컨벤션에 맞게 작성했습니다.
- [ ] 변경 사항에 대한 테스트를 했습니다.(버그 수정/기능에 대한 테스트).

### 🔎 작업 내용

<!-- 어떤 작업을 하셨는지 상세하게 작성해주세요-->

- sizes, types, baseClasses 상수를 컴포넌트 외부로 이동
- 기존의 코드는 해당 상수들이 컴포넌트 내부에 지역적으로 선언되고 있었음.
- 수정 후 컴포넌트가 재렌더링될 때마다 불필요한 재정의 방지 && 기존의 값을 재사용 가능

### 이슈

<!-- 이슈 키워드와 함께 #을 입력한 후 이슈 번호를 선택해주세요. -->
<!-- 에시 : resolves #1 -->

resolves #64 
