### PR TITLE
bugfix : IconRankMoreList 컴포넌트 마크업 재설계

### DIFF
--- a/src/components/atomic/IconRankMoreList.jsx
+++ b/src/components/atomic/IconRankMoreList.jsx
@@ -1,23 +1,49 @@
 import PropTypes from 'prop-types';
 
-const IconRankMoreList = ({ rank = 1, emotion = '감정', count = 0 }) => {
+const emotions = {
+  신나는: '/icons/emotions/popper.png',
+  편안한: '/icons/emotions/comfortable.png',
+  뿌듯한: '/icons/emotions/proud.png',
+  기대되는: '/icons/emotions/gift.png',
+  행복한: '/icons/emotions/flower.png',
+  의욕적인: '/icons/emotions/motivation.png',
+  설레는: '/icons/emotions/ballon.png',
+  상쾌한: '/icons/emotions/juice.png',
+  차분한: '/icons/emotions/calm.png',
+  감사한: '/icons/emotions/thankful.png',
+  우울한: '/icons/emotions/gloomy.png',
+  외로운: '/icons/emotions/leaves.png',
+  불안한: '/icons/emotions/anxious.png',
+  슬픈: '/icons/emotions/tears.png',
+  화난: '/icons/emotions/volcano.png',
+  부담되는: '/icons/emotions/pressure.png',
+  짜증나는: '/icons/emotions/annoyed.png',
+  피곤한: '/icons/emotions/tired.png',
+  스트레스: '/icons/emotions/stressful.png',
+  답답한: '/icons/emotions/hoguma.png',
+};
+
+const IconRankMoreList = ({ rank = 1, emotion = '신나는', count = 0 }) => {
   return (
-    <div
-      className="flex w-full p-2 items-center gap-[15px]"
-      aria-labelledby="rankLabel emotionLabel countLabel"
-    >
-      <span
-        id="rankLabel"
+    <section className="flex w-full p-2 items-center gap-[15px]">
+      <h2
         className="w-6 text-lg font-semibold text-left text-blue-500"
+        aria-label={`순위 ${rank}위`}
       >
-        {rank}
-      </span>
-      <span className="inline-block w-10 h-10 rounded-full bg-blue-50"></span>
-      <div className="flex flex-col gap-[5px] items-start content-center text-blue-500 text-sm font-medium">
-        <span id="emotionLabel">{emotion}</span>
-        <span id="countLabel">{`${count}회`}</span>
-      </div>
-    </div>
+        <span aria-hidden="true">{rank}</span>
+      </h2>
+      <figure className="flex flex-row gap-[15px] items-start content-center text-blue-500 text-sm font-medium">
+        <img
+          src={emotions[emotion]}
+          className="w-10 h-10"
+          alt={`${emotion} 상태를 나타내는 아이콘`}
+        />
+        <figcaption className="flex flex-col gap-[5px]">
+          <span>{emotion}</span>
+          <span aria-label="이 감정이 기록된 횟수">{`${count}회`}</span>
+        </figcaption>
+      </figure>
+    </section>
   );
 };
 


### PR DESCRIPTION
### 제목 : feat(issue 번호): bugfix : IconRankMoreList 컴포넌트 마크업 재설계

### PR 유형

- [ ] 새로운 기능 추가
- [ ] 버그 수정
- [ ] CSS 등 사용자 UI 디자인 변경
- [ ] 코드에 영향을 주지 않는 변경사항(오타 수정, 탭 사이즈 변경, 변수명 변경)
- [x] 코드 리팩토링
- [ ] 주석 추가 및 수정
- [ ] 문서 수정
- [ ] 테스트 추가, 테스트 리팩토링
- [ ] 빌드 부분 혹은 패키지 매니저 수정
- [ ] 파일 혹은 폴더명 수정
- [ ] 파일 혹은 폴더 삭제

### PR 체크리스트

<!-- PR이 다음 요구 사항을 충족하는지 확인하세요. -->

- [x] 커밋 메시지 컨벤션에 맞게 작성했습니다.
- [ ] 변경 사항에 대한 테스트를 했습니다.(버그 수정/기능에 대한 테스트).

### 🔎 작업 내용

- ```<section>``` 태그로 전체 태그를 감싸고 그 내부에 ```<h2>```와 ```<figure>```로 설계
- 속성으로 들어온 감정에 따라 이모티콘 이미지가 렌더링될 수 있도록 수정

  <br />

### 이슈

- 이전에 작업했던 refactor/iconrankmorelist 브랜치를 최신화했는데 깃으로 넘어오지 않아서 새로운 bugfix/iconrankmorelist 브랜치를 만들어 작업했음
- 알고보니까, feature/iconrankmorelist 브랜치와 refactor/iconrankmorelist 브랜치를 혼동해서 작업한 거였음. 


resolves #91
