### PR TITLE
refactor: 커스텀 훅 분리 및 컴포넌트에서 날짜 선택 시 캘린더에 반영될 수 있도록 수정

### DIFF
--- a/src/components/common/DiaryDetail.jsx
+++ b/src/components/common/DiaryDetail.jsx
@@ -1,41 +1,23 @@
+import emotions from '@/assets/icons/emotions/emotions';
 import { Delete, Edit } from '@/assets/icons/menu';
 import moods from '@/assets/icons/mood/moods';
-import emotions from '@/assets/icons/emotions/emotions';
-import { useFetchMonthlyDiaryData } from '@/hooks';
-import PropTypes from 'prop-types';
-import { useEffect, useState } from 'react';
 import weathers from '@/assets/icons/weather/weathers';
+import PropTypes from 'prop-types';
 
-const DiaryDetail = ({ selectedDate }) => {
-  const [diaryEntry, setDiaryEntry] = useState(null);
-  const { diaryData, loading } = useFetchMonthlyDiaryData();
-
+const DiaryDetail = ({ diaryDetail }) => {
+  console.log(diaryDetail);
   const baseImageUrl = `${import.meta.env.VITE_PB_API}/files/diary`;
 
-  useEffect(() => {
-    if (selectedDate) {
-      const entry = diaryData.find((entry) => entry.date === selectedDate);
-      setDiaryEntry(entry);
-    }
-  }, [selectedDate, diaryData]);
+  if (!diaryDetail) return;
 
-  if (loading) {
-    console.log('로딩 중..');
-    {
-      /* 추후 로딩 처리 로직을 가져오거나..등 */
-    }
-  }
-
-  if (!diaryEntry) return;
-
-  const dateObj = new Date(diaryEntry.date);
+  const dateObj = new Date(diaryDetail.date);
   const day = dateObj.getDate();
   const weekDays = ['일', '월', '화', '수', '목', '금', '토'];
   const weekday = weekDays[dateObj.getDay()];
   const dateFormatted = `${day} ${weekday}`;
 
   // 감정 아이콘 최대 5개,  날씨 아이콘 최대 5개
-  const combinedIcons = [...diaryEntry.emotion, ...diaryEntry.weather].slice(
+  const combinedIcons = [...diaryDetail.emotion, ...diaryDetail.weather].slice(
     0.7
   );
 
@@ -54,9 +36,9 @@ const DiaryDetail = ({ selectedDate }) => {
       <div className="flex flex-col gap-y-5">
         <div className="flex flex-col items-center gap-2">
           <img
-            key={diaryEntry.date}
-            src={moods[diaryEntry.mood]}
-            alt={`${diaryEntry.mood} 아이콘`}
+            key={diaryDetail.date}
+            src={moods[diaryDetail.mood]}
+            alt={`${diaryDetail.mood} 아이콘`}
             className="w-[44px] h-[44px]"
           />
           <span className="text-base font-semibold text-gray-450">
@@ -75,20 +57,20 @@ const DiaryDetail = ({ selectedDate }) => {
           ))}
         </div>
 
-        {diaryEntry.picture ? (
+        {diaryDetail.picture ? (
           <>
             <img
-              src={`${baseImageUrl}/${diaryEntry.id}/${diaryEntry.picture}`}
+              src={`${baseImageUrl}/${diaryDetail.id}/${diaryDetail.picture}`}
               className="w-full rounded-xl bg-blue-50"
-              alt={`${diaryEntry.date}의 사진`}
+              alt={`${diaryDetail.date}의 사진`}
             />
             <p className="text-sm font-medium leading-normal text-blue-500">
-              {diaryEntry.content}
+              {diaryDetail.content}
             </p>
           </>
         ) : (
           <p className="text-sm font-medium leading-relaxed text-blue-500">
-            {diaryEntry.content}
+            {diaryDetail.content}
           </p>
         )}
       </div>
@@ -97,7 +79,7 @@ const DiaryDetail = ({ selectedDate }) => {
 };
 
 DiaryDetail.propTypes = {
-  selectedDate: PropTypes.string.isRequired,
+  diaryDetail: PropTypes.object.isRequired,
 };
 
 export default DiaryDetail;

--- a/src/components/common/DiaryDetail.jsx
+++ b/src/components/common/DiaryDetail.jsx
@@ -1,14 +1,14 @@
 import { Delete, Edit } from '@/assets/icons/menu';
 import moods from '@/assets/icons/mood/moods';
 import emotions from '@/assets/icons/emotions/emotions';
-import { useFetchDiaryData } from '@/hooks';
+import { useFetchMonthlyDiaryData } from '@/hooks';
 import PropTypes from 'prop-types';
 import { useEffect, useState } from 'react';
 import weathers from '@/assets/icons/weather/weathers';
 
 const DiaryDetail = ({ selectedDate }) => {
   const [diaryEntry, setDiaryEntry] = useState(null);
-  const { diaryData, loading } = useFetchDiaryData();
+  const { diaryData, loading } = useFetchMonthlyDiaryData();
 
   const baseImageUrl = `${import.meta.env.VITE_PB_API}/files/diary`;
 

--- a/src/components/common/DiaryDetail.jsx
+++ b/src/components/common/DiaryDetail.jsx
@@ -5,7 +5,6 @@ import weathers from '@/assets/icons/weather/weathers';
 import PropTypes from 'prop-types';
 
 const DiaryDetail = ({ diaryDetail }) => {
-  console.log(diaryDetail);
   const baseImageUrl = `${import.meta.env.VITE_PB_API}/files/diary`;
 
   if (!diaryDetail) return;

--- a/src/components/home/Calendar.jsx
+++ b/src/components/home/Calendar.jsx
@@ -8,7 +8,6 @@ const Calendar = ({
   diaryData = [],
   selectedMonth = format(new Date(), 'yyyy-MM'),
 }) => {
-  console.log(selectedMonth);
   const { weekRows } = useCalendar(diaryData, selectedMonth);
 
   return (

--- a/src/components/home/Calendar.jsx
+++ b/src/components/home/Calendar.jsx
@@ -1,10 +1,15 @@
 import { useCalendar } from '@/hooks';
+import { format } from 'date-fns';
 import PropTypes from 'prop-types';
 
 const WEEKS = ['일', '월', '화', '수', '목', '금', '토'];
 
-const Calendar = ({ diaryData = [] }) => {
-  const { weekRows } = useCalendar(diaryData);
+const Calendar = ({
+  diaryData = [],
+  selectedMonth = format(new Date(), 'yyyy-MM'),
+}) => {
+  console.log(selectedMonth);
+  const { weekRows } = useCalendar(diaryData, selectedMonth);
 
   return (
     <table className="w-full border-separate border-spacing-y-5 border-spacing-x-0">
@@ -29,6 +34,7 @@ const Calendar = ({ diaryData = [] }) => {
 
 Calendar.propTypes = {
   diaryData: PropTypes.array,
+  selectedMonth: PropTypes.string,
 };
 
 export default Calendar;

--- a/src/components/home/FeelingCalendar.jsx
+++ b/src/components/home/FeelingCalendar.jsx
@@ -3,11 +3,11 @@ import moods from '@/assets/icons/mood/moods';
 import PropTypes from 'prop-types';
 import { useNavigate } from 'react-router-dom';
 
-const FeelingCalendar = ({ day, mood, date }) => {
+const FeelingCalendar = ({ day, mood, id }) => {
   const navigate = useNavigate();
 
   const handleClick = () => {
-    navigate(`/diary/${date}`);
+    navigate(`/diary/detail/${id}`);
   };
 
   return (
@@ -32,7 +32,7 @@ const FeelingCalendar = ({ day, mood, date }) => {
 FeelingCalendar.propTypes = {
   day: PropTypes.number.isRequired,
   mood: PropTypes.string,
-  date: PropTypes.string.isRequired,
+  id: PropTypes.string.isRequired,
 };
 
 export default FeelingCalendar;

--- a/src/components/home/FeelingCalendar.jsx
+++ b/src/components/home/FeelingCalendar.jsx
@@ -7,7 +7,7 @@ const FeelingCalendar = ({ day, mood, date }) => {
   const navigate = useNavigate();
 
   const handleClick = () => {
-    navigate('/diary/detail', { state: { selectedDate: date } });
+    navigate(`/diary/${date}`);
   };
 
   return (

--- a/src/hooks/index.js
+++ b/src/hooks/index.js
@@ -1,2 +1,3 @@
 export { default as useCalendar } from './useCalendar.jsx';
-export { default as useFetchDiaryData } from './useFetchDiaryData.jsx';
+export { default as useFetchAllDiaryData } from './useFetchAllDiaryData.jsx';
+export { default as useFetchMonthlyDiaryData } from './useFetchMonthlyDiaryData.jsx';

--- a/src/hooks/index.js
+++ b/src/hooks/index.js
@@ -1,4 +1,5 @@
 export { default as useCalendar } from './useCalendar.jsx';
 export { default as useModal } from './useModal.js';
 export { default as useFetchAllDiaryData } from './useFetchAllDiaryData.jsx';
+export { default as useFetchDiaryDetail } from './useFetchDiaryDetail.jsx';
 export { default as useFetchMonthlyDiaryData } from './useFetchMonthlyDiaryData.jsx';

--- a/src/hooks/index.js
+++ b/src/hooks/index.js
@@ -1,5 +1,4 @@
 export { default as useCalendar } from './useCalendar.jsx';
-export { default as useFetchDiaryData } from './useFetchDiaryData.jsx';
 export { default as useModal } from './useModal.js';
 export { default as useFetchAllDiaryData } from './useFetchAllDiaryData.jsx';
 export { default as useFetchMonthlyDiaryData } from './useFetchMonthlyDiaryData.jsx';

--- a/src/hooks/useCalendar.jsx
+++ b/src/hooks/useCalendar.jsx
@@ -65,6 +65,7 @@ const useCalendar = (
                 day={parseInt(format(day, 'd'), 10)}
                 mood={dayDiary ? dayDiary.mood : undefined}
                 date={formattedDate}
+                id={dayDiary ? dayDiary.id : ''}
               />
             </td>
           ),

--- a/src/hooks/useCalendar.jsx
+++ b/src/hooks/useCalendar.jsx
@@ -7,10 +7,22 @@ import {
   startOfMonth,
   startOfWeek,
 } from 'date-fns';
-import { useMemo, useState } from 'react';
+import PropTypes from 'prop-types';
+import { useEffect, useMemo, useState } from 'react';
 
-const useCalendar = (diaryData) => {
-  const [currentDate, setCurrentDate] = useState(new Date());
+const useCalendar = (
+  diaryData,
+  selectedMonth = format(new Date(), 'yyyy-MM')
+) => {
+  const [currentDate, setCurrentDate] = useState(
+    new Date(`${selectedMonth}-01`)
+  );
+
+  useEffect(() => {
+    if (selectedMonth) {
+      setCurrentDate(new Date(`${selectedMonth}-01`));
+    }
+  }, [selectedMonth]);
 
   const month = useMemo(() => getMonth(currentDate), [currentDate]);
   const firstDayOfMonth = useMemo(
@@ -66,6 +78,11 @@ const useCalendar = (diaryData) => {
   }, [diaryData, firstDayOfCalendar, weeksInMonth, month]);
 
   return { weekRows, currentDate, setCurrentDate };
+};
+
+useCalendar.propTypes = {
+  diaryData: PropTypes.array,
+  selectedMonth: PropTypes.string,
 };
 
 export default useCalendar;

--- a/src/hooks/useFetchAllDiaryData.jsx
+++ b/src/hooks/useFetchAllDiaryData.jsx
@@ -2,7 +2,7 @@ import pb from '@/api/pb';
 import { useEffect, useState } from 'react';
 import { useNavigate } from 'react-router-dom';
 
-const useFetchDiaryData = () => {
+const useFetchAllDiaryData = () => {
   const [diaryData, setDiaryData] = useState([]);
   const [loading, setLoading] = useState(true);
   const navigate = useNavigate();
@@ -43,4 +43,4 @@ const useFetchDiaryData = () => {
   return { diaryData, loading };
 };
 
-export default useFetchDiaryData;
+export default useFetchAllDiaryData;

--- a/src/hooks/useFetchDiaryDetail.jsx
+++ b/src/hooks/useFetchDiaryDetail.jsx
@@ -1,0 +1,39 @@
+import pb from '@/api/pb';
+import { useEffect, useState } from 'react';
+import { useNavigate } from 'react-router-dom';
+
+const useFetchDiaryDetail = (diaryId) => {
+  const [diaryDetail, setDiaryDetail] = useState(null);
+  const [loading, setLoading] = useState(true);
+  const navigate = useNavigate();
+
+  useEffect(() => {
+    const getData = async () => {
+      try {
+        const record = await pb.collection('diary').getOne(diaryId);
+
+        setDiaryDetail({
+          date: record.date.split(' ')[0],
+          id: record.id,
+          mood: record.mood,
+          emotion: record.emotion,
+          weather: record.weather,
+          picture: record.picture,
+          content: record.content,
+        });
+      } catch (error) {
+        if (error.status === 0) return;
+        console.error('Data fetch error', error);
+        navigate('/error');
+      } finally {
+        setLoading(false);
+      }
+    };
+
+    getData();
+  }, [diaryId, navigate]);
+
+  return { diaryDetail, loading };
+};
+
+export default useFetchDiaryDetail;

--- a/src/hooks/useFetchMonthlyDiaryData.jsx
+++ b/src/hooks/useFetchMonthlyDiaryData.jsx
@@ -1,0 +1,53 @@
+import pb from '@/api/pb';
+import PropTypes from 'prop-types';
+import { useEffect, useState } from 'react';
+import { useNavigate } from 'react-router-dom';
+
+const useFetchMonthlyDiaryData = (selectedMonth) => {
+  const [diaryData, setDiaryData] = useState([]);
+  const [loading, setLoading] = useState(true);
+  const navigate = useNavigate();
+
+  useEffect(() => {
+    const getData = async () => {
+      try {
+        const records = await pb.collection('diary').getList(1, 31, {
+          filter: `date >= "${selectedMonth}-01 00:00:00" && date <= "${selectedMonth}-31 23:59:59"`,
+          // 현재, pb 서버에 임의의 db를 넣느라 임의로 정렬 설정 해 놓음.
+          // 추후 `-created` 등 변경 필요!!
+          sort: 'date',
+        });
+
+        const formattedData = records.items.map(
+          ({ date, id, mood, emotion, weather, picture, content }) => ({
+            date: date.split(' ')[0],
+            id,
+            mood,
+            emotion,
+            weather,
+            picture,
+            content,
+          })
+        );
+        setDiaryData(formattedData);
+        console.log(formattedData);
+      } catch (error) {
+        if (error.status === 0) return;
+        console.error('Data fetch error', error);
+        navigate('/error');
+      } finally {
+        setLoading(false);
+      }
+    };
+
+    getData();
+  }, [selectedMonth, navigate]);
+
+  return { diaryData, loading };
+};
+
+useFetchMonthlyDiaryData.propTypes = {
+  diaryData: PropTypes.string.isRequired,
+};
+
+export default useFetchMonthlyDiaryData;

--- a/src/hooks/useFetchMonthlyDiaryData.jsx
+++ b/src/hooks/useFetchMonthlyDiaryData.jsx
@@ -30,7 +30,6 @@ const useFetchMonthlyDiaryData = (selectedMonth) => {
           })
         );
         setDiaryData(formattedData);
-        console.log(formattedData);
       } catch (error) {
         if (error.status === 0) return;
         console.error('Data fetch error', error);

--- a/src/pages/Home.jsx
+++ b/src/pages/Home.jsx
@@ -1,8 +1,6 @@
 import { Calendar, DiaryCard, TopNavigation, YearMonth } from '@/components';
-import { useFetchDiaryData } from '@/hooks';
+import { useFetchMonthlyDiaryData } from '@/hooks';
 import { format } from 'date-fns';
-import { useEffect } from 'react';
-
 import { useState } from 'react';
 import { Helmet } from 'react-helmet-async';
 
@@ -12,11 +10,7 @@ const Home = () => {
     format(new Date(), 'yyyy-MM')
   );
 
-  useEffect(() => {
-    console.log(selectedMonth);
-  }, [selectedMonth]);
-
-  const { diaryData, loading } = useFetchDiaryData();
+  const { diaryData, loading } = useFetchMonthlyDiaryData(selectedMonth);
 
   const handleToggleView = () => {
     setViewMode((prevMode) => (prevMode === 'calendar' ? 'list' : 'calendar'));
@@ -55,7 +49,7 @@ const Home = () => {
           className="py-5"
         />
         {viewMode === 'calendar' ? (
-          <Calendar diaryData={diaryData} />
+          <Calendar diaryData={diaryData} selectedMonth={selectedMonth} />
         ) : (
           <main className="flex flex-col gap-5">
             {diaryData.map((diary) => (

--- a/src/pages/diary/DetailDiary.jsx
+++ b/src/pages/diary/DetailDiary.jsx
@@ -1,13 +1,32 @@
 import { DiaryDetail, TopHeader } from '@/components';
+import { useFetchDiaryDetail } from '@/hooks';
+import { useEffect, useState } from 'react';
 import { useParams } from 'react-router-dom';
 
 const DetailDiary = () => {
-  const { date } = useParams();
+  const { id } = useParams();
+  const { diaryDetail, loading } = useFetchDiaryDetail(id);
+  const [diaryDate, setDiaryDate] = useState('');
+
+  useEffect(() => {
+    if (diaryDetail) {
+      setDiaryDate(diaryDetail.date);
+    }
+  }, [diaryDetail]);
+
+  if (loading) {
+    console.log('로딩 중..');
+    {
+      /* 추후 로딩 처리 로직을 가져오거나..등 */
+    }
+  }
+
+  if (!diaryDate) return;
 
   return (
     <div>
-      <TopHeader isShowIcon={true} title={date} />
-      <DiaryDetail selectedDate={date} />
+      <TopHeader isShowIcon={true} title={diaryDate} />
+      <DiaryDetail diaryDetail={diaryDetail} />
     </div>
   );
 };

--- a/src/pages/diary/DetailDiary.jsx
+++ b/src/pages/diary/DetailDiary.jsx
@@ -1,14 +1,13 @@
 import { DiaryDetail, TopHeader } from '@/components';
-import { useLocation } from 'react-router-dom';
+import { useParams } from 'react-router-dom';
 
 const DetailDiary = () => {
-  const location = useLocation();
-  const selectedDate = location.state?.selectedDate;
+  const { date } = useParams();
 
   return (
     <div>
-      <TopHeader isShowIcon={true} title={selectedDate} />
-      <DiaryDetail selectedDate={selectedDate} />
+      <TopHeader isShowIcon={true} title={date} />
+      <DiaryDetail selectedDate={date} />
     </div>
   );
 };

--- a/src/pages/mypage/PhotoGallery.jsx
+++ b/src/pages/mypage/PhotoGallery.jsx
@@ -1,9 +1,9 @@
 import { TopHeader } from '@/components';
-import { useFetchDiaryData } from '@/hooks';
+import { useFetchAllDiaryData } from '@/hooks';
 import { Helmet } from 'react-helmet-async';
 
 const PhotoGallery = () => {
-  const { diaryData, loading } = useFetchDiaryData();
+  const { diaryData, loading } = useFetchAllDiaryData();
 
   const baseImageUrl = `${import.meta.env.VITE_PB_API}/files/diary`;
 

--- a/src/router.jsx
+++ b/src/router.jsx
@@ -51,7 +51,7 @@ export const routes = [
       {
         path: 'diary',
         children: [
-          { path: ':date', element: <DetailDiary /> },
+          { path: 'detail/:id', element: <DetailDiary /> },
           { path: 'new', lazy: () => import('@/pages/diary/NewDiary') },
           { path: 'edit', lazy: () => import('@/pages/diary/EditDiary') },
         ],

--- a/src/router.jsx
+++ b/src/router.jsx
@@ -43,7 +43,7 @@ export const routes = [
       {
         path: 'diary',
         children: [
-          { path: 'detail', element: <DetailDiary /> },
+          { path: ':date', element: <DetailDiary /> },
           { path: 'new', lazy: () => import('@/pages/diary/NewDiary') },
           { path: 'edit', lazy: () => import('@/pages/diary/EditDiary') },
         ],


### PR DESCRIPTION
### 제목 : refactor: 커스텀 훅 분리 및 컴포넌트에서 날짜 선택 시 캘린더에 반영될 수 있도록 수정

### PR 유형

- [ ] 새로운 기능 추가
- [ ] 버그 수정
- [ ] CSS 등 사용자 UI 디자인 변경
- [ ] 코드에 영향을 주지 않는 변경사항(오타 수정, 탭 사이즈 변경, 변수명 변경)
- [x] 코드 리팩토링
- [ ] 주석 추가 및 수정
- [ ] 문서 수정
- [ ] 테스트 추가, 테스트 리팩토링
- [ ] 빌드 부분 혹은 패키지 매니저 수정
- [ ] 파일 혹은 폴더명 수정
- [ ] 파일 혹은 폴더 삭제

### PR 체크리스트

<!-- PR이 다음 요구 사항을 충족하는지 확인하세요. -->

- [x] 커밋 메시지 컨벤션에 맞게 작성했습니다.
- [ ] 변경 사항에 대한 테스트를 했습니다.(버그 수정/기능에 대한 테스트).

### 🔎 작업 내용

<!-- 어떤 작업을 하셨는지 상세하게 작성해주세요-->

- 기존  useFetchDiaryData 는 전체 다이어리 데이터 만을 가져왔음.
- 이것을 useFetchAllDiaryData (전체 다이어리 데이터)와 useFetchMonthlyDiaryData(선택한 Month의 데이터만) 훅으로 분리함.
- YearMonth에서 날짜 선택 시, 캘린더에서도 선택 날짜에 따라 달력이 변경 될 수 있도록 개선함
![image](https://github.com/user-attachments/assets/7f017654-4446-43e5-bc4e-d98eb837ceaf)

  <br />

### 🔧 앞으로의 과제


### 이슈

<!-- 이슈 키워드와 함께 #을 입력한 후 이슈 번호를 선택해주세요. -->
<!-- 에시 : resolves #1 -->

resolves #128 
