### PR TITLE
feat: 일기가 없는 날짜를 클릭하면 일기 작성 페이지로 이동할 수 있도록 구현

### DIFF
--- a/src/components/home/FeelingCalendar.jsx
+++ b/src/components/home/FeelingCalendar.jsx
@@ -1,30 +1,44 @@
 import DayCircle from '@/assets/icons/daycircle/daycircle.svg?react';
 import moods from '@/assets/icons/mood/moods';
+import { isFuture } from 'date-fns';
 import PropTypes from 'prop-types';
+import toast, { Toaster } from 'react-hot-toast';
 import { useNavigate } from 'react-router-dom';
 
-const FeelingCalendar = ({ day, mood, id }) => {
+const FeelingCalendar = ({ day, mood, id, date }) => {
   const navigate = useNavigate();
 
   const handleClick = () => {
-    navigate(`/diary/detail/${id}`);
+    const selectedDate = new Date(date);
+
+    if (isFuture(selectedDate)) {
+      toast.error('미래의 일기는 아직 기록할 수 없어요!');
+      return;
+    }
+
+    if (id) {
+      navigate(`/diary/detail/${id}`);
+    } else {
+      navigate(`/diary/new`, { state: { date } });
+    }
   };
 
   return (
     <div className="flex items-center flex-col gap-[7px]">
-      {mood ? (
-        <button onClick={handleClick} type="button">
+      <button onClick={handleClick} type="button">
+        {mood ? (
           <img
             src={moods[mood]}
             alt={mood}
             className="w-[44px] h-[44px] cursor-pointer"
           />
-        </button>
-      ) : (
-        // 추후 일기 해당 날짜 일기 작성으로 이동
-        <DayCircle className="fill-blue-50 w-[44px] h-[44px]" />
-      )}
+        ) : (
+          // 추후 일기 해당 날짜 일기 작성으로 이동
+          <DayCircle className="fill-blue-50 w-[44px] h-[44px] cursor-pointer" />
+        )}
+      </button>
       <span>{day}</span>
+      <Toaster />
     </div>
   );
 };
@@ -33,6 +47,7 @@ FeelingCalendar.propTypes = {
   day: PropTypes.number.isRequired,
   mood: PropTypes.string,
   id: PropTypes.string.isRequired,
+  date: PropTypes.string.isRequired,
 };
 
 export default FeelingCalendar;

--- a/src/components/newdiary/SelectMood.jsx
+++ b/src/components/newdiary/SelectMood.jsx
@@ -36,7 +36,7 @@ const SelectMood = ({ isSelected, setSelected }) => {
       <h2 className="text-base font-semibold text-gray-450">
         오늘 하루는 어떠셨나요?
       </h2>
-      <ul className="justify-start items-center gap-[17px] flex">
+      <ul className="flex items-center justify-between w-full px-5">
         {emotionItems}
       </ul>
     </div>

--- a/src/pages/diary/DetailDiary.jsx
+++ b/src/pages/diary/DetailDiary.jsx
@@ -3,7 +3,7 @@ import { useFetchDiaryDetail } from '@/hooks';
 import { useEffect, useState } from 'react';
 import { useParams } from 'react-router-dom';
 
-const DetailDiary = () => {
+export const Component = () => {
   const { id } = useParams();
   const { diaryDetail, loading } = useFetchDiaryDetail(id);
   const [diaryDate, setDiaryDate] = useState('');
@@ -30,5 +30,3 @@ const DetailDiary = () => {
     </section>
   );
 };
-
-export default DetailDiary;

--- a/src/pages/diary/NewDiary.jsx
+++ b/src/pages/diary/NewDiary.jsx
@@ -1,4 +1,5 @@
-import { useState } from 'react';
+import emotions from '@/assets/icons/emotions/emotions';
+import weathers from '@/assets/icons/weather/weathers';
 import {
   Accordion,
   SelectMood,
@@ -7,11 +8,16 @@ import {
   TopHeader,
   WeatherWithIcon,
 } from '@/components';
-import emotions from '@/assets/icons/emotions/emotions';
-import weathers from '@/assets/icons/weather/weathers';
+import { format } from 'date-fns';
+import { useState } from 'react';
 import toast, { Toaster } from 'react-hot-toast';
+import { useLocation } from 'react-router-dom';
 
 export const Component = () => {
+  const location = useLocation();
+  const { date } = location.state || {};
+  const defaultTitle = date || format(new Date(), 'yyyy-MM-dd'); //
+
   const [selectedMood, setSelectedMood] = useState(null);
   const [selectedEmotions, setSelectedEmotions] = useState([]);
   const [selectedWeathers, setSelectedWeathers] = useState([]);
@@ -46,7 +52,7 @@ export const Component = () => {
 
   return (
     <section className="flex flex-col gap-5 pb-[100px]">
-      <TopHeader title={'일기작성'} isShowIcon={true} />
+      <TopHeader title={defaultTitle} isShowIcon={true} />
       <SelectMood isSelected={selectedMood} setSelected={setSelectedMood} />
       <Accordion open={true} title="감정" className="grid grid-cols-5 gap-4">
         {Object.entries(emotions).map(([key, src]) => (

--- a/src/pages/index.js
+++ b/src/pages/index.js
@@ -7,7 +7,7 @@ export { default as Chart } from './chart/Chart.jsx';
 export { default as ChartMoreList } from './chart/ChartMoreList.jsx';
 
 // diary
-export { default as DetailDiary } from './diary/DetailDiary.jsx';
+// export { default as DetailDiary } from './diary/DetailDiary.jsx';
 
 // mypage
 export { default as BuddyManagement } from './mypage/BuddyManagement.jsx';

--- a/src/router.jsx
+++ b/src/router.jsx
@@ -4,7 +4,6 @@ import {
   BuddyManagement,
   Chart,
   ChartMoreList,
-  DetailDiary,
   ErrorPage,
   Home,
   Login,
@@ -16,7 +15,7 @@ import {
   Register,
 } from './pages';
 
-/**@type {import('react-router-dom').RouteObject[]} */
+/*@type {import('react-router-dom').RouteObject[]}*/
 export const routes = [
   {
     path: '/',
@@ -51,7 +50,10 @@ export const routes = [
       {
         path: 'diary',
         children: [
-          { path: 'detail/:id', element: <DetailDiary /> },
+          {
+            path: 'detail/:id',
+            lazy: () => import('@/pages/diary/DetailDiary'),
+          },
           { path: 'new', lazy: () => import('@/pages/diary/NewDiary') },
           { path: 'edit', lazy: () => import('@/pages/diary/EditDiary') },
         ],


### PR DESCRIPTION
### 제목 : [feat: 일기가 없는 날짜를 클릭하면 일기 작성 페이지로 이동할 수 있도록 구현](https://github.com/FRONTENDSCHOOL10/Samcho/commit/f0814198a517173d3d0827483b6ad2ffd6ffb234)

### PR 유형

- [x] 새로운 기능 추가
- [ ] 버그 수정
- [ ] CSS 등 사용자 UI 디자인 변경
- [ ] 코드에 영향을 주지 않는 변경사항(오타 수정, 탭 사이즈 변경, 변수명 변경)
- [ ] 코드 리팩토링
- [ ] 주석 추가 및 수정
- [ ] 문서 수정
- [ ] 테스트 추가, 테스트 리팩토링
- [ ] 빌드 부분 혹은 패키지 매니저 수정
- [ ] 파일 혹은 폴더명 수정
- [ ] 파일 혹은 폴더 삭제

### PR 체크리스트

<!-- PR이 다음 요구 사항을 충족하는지 확인하세요. -->

- [x] 커밋 메시지 컨벤션에 맞게 작성했습니다.
- [ ] 변경 사항에 대한 테스트를 했습니다.(버그 수정/기능에 대한 테스트).

### 🔎 작업 내용

<!-- 어떤 작업을 하셨는지 상세하게 작성해주세요-->

- 사용자들이 일기가 없는 날짜를 클릭하면 일기 작성 페이지로 이동할 수 있도록 기능 추가
- 미래의 날짜는 일기를 작성할 수 없도록 제한하고, 에러 토스트 메세지 추가
- 일기 작성 페이지의 제목이 사용자가 선택한 날짜에 따라 동적으로 업데이트되도록 수정
  <br />

### 🔧 앞으로의 과제

  <br />

### 이슈

<!-- 이슈 키워드와 함께 #을 입력한 후 이슈 번호를 선택해주세요. -->
<!-- 에시 : resolves #1 -->

resolves #143 
