### PR TITLE
feat: 단짝 관리 기능 구현

### DIFF
--- a/src/hooks/useFetchBuddyData.jsx
+++ b/src/hooks/useFetchBuddyData.jsx
@@ -1,0 +1,54 @@
+import { useState, useEffect } from 'react';
+import pb from '@/api/pb';
+import { useNavigate } from 'react-router-dom';
+
+const useFetchBuddyData = () => {
+  const [buddyData, setBuddyData] = useState([]);
+  const [loading, setLoading] = useState(true);
+  const navigate = useNavigate();
+
+  const userId = JSON.parse(localStorage.getItem('auth'))?.user?.id;
+
+  useEffect(() => {
+    let isMounted = true;
+
+    const fetchBuddyData = async () => {
+      try {
+        const records = await pb.collection('buddy').getFullList({
+          filter: `user = "${userId}"`,
+          sort: '-created',
+          expand: 'buddy',
+        });
+
+        if (isMounted) {
+          const formattedData = records.map((record) => ({
+            buddyId: record.buddy,
+            buddyName: record.expand.buddy?.name || 'Unknown',
+            created: record.created,
+          }));
+
+          setBuddyData(formattedData);
+        }
+      } catch (error) {
+        if (isMounted) {
+          console.error('Data fetch error', error);
+          navigate('/error');
+        }
+      } finally {
+        if (isMounted) {
+          setLoading(false);
+        }
+      }
+    };
+
+    fetchBuddyData();
+
+    return () => {
+      isMounted = false;
+    };
+  }, [navigate, userId]);
+
+  return { buddyData, loading };
+};
+
+export default useFetchBuddyData;

--- a/src/pages/mypage/BuddyCard.jsx
+++ b/src/pages/mypage/BuddyCard.jsx
@@ -1,11 +1,33 @@
+import React from 'react';
 import { PropTypes } from 'prop-types';
 import { differenceInDays, format } from 'date-fns';
+import pb from '@/api/pb';
 
-const BuddyCard = ({ buddyName, startDate }) => {
+const BuddyCard = React.memo(({ buddyName, startDate, buddyId, onDelete }) => {
   const daysDifference = differenceInDays(
     format(new Date(), 'yyyy-MM-dd'),
     startDate
   );
+
+  const handleDelete = async () => {
+    try {
+      const userId = JSON.parse(localStorage.getItem('auth')).user.id;
+
+      const records = await pb.collection('buddy').getFullList({
+        filter: `(user = "${userId}" && buddy = "${buddyId}") || (user = "${buddyId}" && buddy = "${userId}")`,
+      });
+
+      const deletePromises = records.map((record) =>
+        pb.collection('buddy').delete(record.id)
+      );
+
+      await Promise.all(deletePromises);
+
+      onDelete(buddyId);
+    } catch (error) {
+      console.error('단짝 삭제 중 오류 발생:', error);
+    }
+  };
 
   return (
     <div className="flex justify-between bg-white py-[13px] px-[18px] rounded-[14px] shadow-light items-center">
@@ -16,17 +38,20 @@ const BuddyCard = ({ buddyName, startDate }) => {
           type="button"
           aria-label={`${buddyName}님과 절교 `}
           className="text-white bg-red w-12 px-[10px] py-[5px] rounded-[5px]"
+          onClick={handleDelete}
         >
           절교
         </button>
       </div>
     </div>
   );
-};
+});
 
 BuddyCard.propTypes = {
   buddyName: PropTypes.string.isRequired,
   startDate: PropTypes.string.isRequired,
+  buddyId: PropTypes.string.isRequired,
+  onDelete: PropTypes.func.isRequired,
 };
 
 export default BuddyCard;

--- a/src/pages/mypage/BuddyManagement.jsx
+++ b/src/pages/mypage/BuddyManagement.jsx
@@ -1,20 +1,44 @@
+import { useState, useEffect, useCallback } from 'react';
 import { TopHeader, BuddyCard } from '@/components';
+import useFetchBuddyData from '@/hooks/useFetchBuddyData';
 
 const BuddyManagement = () => {
+  const { buddyData, loading } = useFetchBuddyData();
+  const [buddies, setBuddies] = useState(buddyData);
+
+  useEffect(() => {
+    setBuddies(buddyData);
+  }, [buddyData]);
+
+  const handleDelete = useCallback((deletedBuddyId) => {
+    setBuddies((prevBuddies) =>
+      prevBuddies.filter((buddy) => buddy.buddyId !== deletedBuddyId)
+    );
+  }, []);
+
+  if (loading) {
+    return <p>로딩중...</p>;
+  }
+
   return (
     <section className="min-h-dvh pb-[80px]">
       <TopHeader title="단짝 관리" isShowIcon={true}></TopHeader>
       <main className="flex flex-col gap-5 mt-5">
         <h2 className="sr-only">단짝 리스트</h2>
-        <BuddyCard buddyName="두팔" startDate="2023-10-04"></BuddyCard>
-        <BuddyCard buddyName="치히로" startDate="2023-09-07"></BuddyCard>
-        <BuddyCard buddyName="소피" startDate="2022-06-16"></BuddyCard>
-        <BuddyCard buddyName="하울" startDate="2024-06-18"></BuddyCard>
-        <BuddyCard buddyName="미츠미" startDate="2023-10-04"></BuddyCard>
-        <BuddyCard buddyName="페이커" startDate="2023-07-06"></BuddyCard>
-        <BuddyCard buddyName="쵸비" startDate="2023-07-09"></BuddyCard>
-        <BuddyCard buddyName="바이퍼" startDate="2023-08-06"></BuddyCard>
-        <BuddyCard buddyName="제카" startDate="2023-09-06"></BuddyCard>
+
+        {buddies.length > 0 ? (
+          buddies.map(({ buddyName, created, buddyId }) => (
+            <BuddyCard
+              key={buddyId}
+              buddyName={buddyName}
+              startDate={created.split(' ')[0]}
+              buddyId={buddyId}
+              onDelete={handleDelete}
+            />
+          ))
+        ) : (
+          <p>단짝이 없습니다..!</p>
+        )}
       </main>
     </section>
   );


### PR DESCRIPTION
### 제목 : feat: 단짝 관리 기능 구현

### PR 유형

- [x] 새로운 기능 추가
- [ ] 버그 수정
- [ ] CSS 등 사용자 UI 디자인 변경
- [ ] 코드에 영향을 주지 않는 변경사항(오타 수정, 탭 사이즈 변경, 변수명 변경)
- [ ] 코드 리팩토링
- [ ] 주석 추가 및 수정
- [ ] 문서 수정
- [ ] 테스트 추가, 테스트 리팩토링
- [ ] 빌드 부분 혹은 패키지 매니저 수정
- [ ] 파일 혹은 폴더명 수정
- [ ] 파일 혹은 폴더 삭제

### PR 체크리스트

<!-- PR이 다음 요구 사항을 충족하는지 확인하세요. -->

- [x] 커밋 메시지 컨벤션에 맞게 작성했습니다.
- [ ] 변경 사항에 대한 테스트를 했습니다.(버그 수정/기능에 대한 테스트).

### 🔎 작업 내용

- 'buddy' collection에서 로그인된 사용자의 단짝 데이터를 가져오는 useFetchBuddyData.jsx 생성.
- 로그인된 사용자와 단짝인 리스트를 전부 보여줌. 
- buddy의 created 필드를 통해 단짝과 몇일째인지 표시
- 절교 버튼을 누를 시 단짝 관계 끊어지고, 포켓베이스에서도 삭제됨.
  <br />

### 구현이미지
![image](https://github.com/user-attachments/assets/00e23d34-e615-47e2-93a9-63a03d54774d)

### 이슈
resolves #155
