### PR TITLE
feat: 기분 필터링 기능 추가

### DIFF
--- a/src/pages/Home.jsx
+++ b/src/pages/Home.jsx
@@ -1,11 +1,11 @@
 import { Calendar, DiaryCard, TopNavigation, YearMonth } from '@/components';
 import { useFetchMonthlyDiaryData } from '@/hooks';
 import { format } from 'date-fns';
-import { useEffect } from 'react';
-import { useState } from 'react';
-import { Helmet } from 'react-helmet-async';
-import { useNavigate, useLocation } from 'react-router-dom';
 import PropTypes from 'prop-types';
+import { useEffect, useMemo, useState } from 'react';
+import { Helmet } from 'react-helmet-async';
+import toast from 'react-hot-toast';
+import { useLocation, useNavigate } from 'react-router-dom';
 
 const Home = ({ viewMode: initialViewMode }) => {
   const navigate = useNavigate();
@@ -26,6 +26,19 @@ const Home = ({ viewMode: initialViewMode }) => {
   }, [location.pathname]);
 
   const { diaryData, loading } = useFetchMonthlyDiaryData(selectedMonth);
+
+  const filteredDiaryData = useMemo(() => {
+    if (selectedMood === '전체') return diaryData;
+    return diaryData.filter((diary) => diary.mood === selectedMood);
+  }, [diaryData, selectedMood]);
+
+  useEffect(() => {
+    if (selectedMood !== '전체' && filteredDiaryData.length === 0) {
+      toast.error(`${selectedMood} 기분의 일기가 없어요😥`, {
+        duration: 3000,
+      });
+    }
+  }, [selectedMood, filteredDiaryData.length]);
 
   const handleToggleView = () => {
     const newViewMode = viewMode === 'calendar' ? 'list' : 'calendar';
@@ -68,11 +81,14 @@ const Home = ({ viewMode: initialViewMode }) => {
           className="py-5"
         />
         {viewMode === 'calendar' ? (
-          <Calendar diaryData={diaryData} selectedMonth={selectedMonth} />
+          <Calendar
+            diaryData={filteredDiaryData}
+            selectedMonth={selectedMonth}
+          />
         ) : (
           <main className="flex flex-col gap-5">
-            {diaryData.length > 0 ? (
-              diaryData.map((diary) => (
+            {filteredDiaryData.length > 0 ? (
+              filteredDiaryData.map((diary) => (
                 <DiaryCard key={diary.id} diary={diary} />
               ))
             ) : (


### PR DESCRIPTION
### 제목 : feat: 기분 필터링 기능 추가

### PR 유형

- [x] 새로운 기능 추가
- [ ] 버그 수정
- [ ] CSS 등 사용자 UI 디자인 변경
- [ ] 코드에 영향을 주지 않는 변경사항(오타 수정, 탭 사이즈 변경, 변수명 변경)
- [ ] 코드 리팩토링
- [ ] 주석 추가 및 수정
- [ ] 문서 수정
- [ ] 테스트 추가, 테스트 리팩토링
- [ ] 빌드 부분 혹은 패키지 매니저 수정
- [ ] 파일 혹은 폴더명 수정
- [ ] 파일 혹은 폴더 삭제

### PR 체크리스트

<!-- PR이 다음 요구 사항을 충족하는지 확인하세요. -->

- [x] 커밋 메시지 컨벤션에 맞게 작성했습니다.
- [ ] 변경 사항에 대한 테스트를 했습니다.(버그 수정/기능에 대한 테스트).

### 🔎 작업 내용

<!-- 어떤 작업을 하셨는지 상세하게 작성해주세요-->

- -사용자가 선택한 기분(mood)에 따라 일기 데이터를 필터링하는 기능 추가
![image](https://github.com/user-attachments/assets/56814e50-a2b4-4596-ac86-6f2c85e0bc09)
  - 새로고침하거나 페이지 이동 시에는 필터 내용이 남아있지 X
- 선택한 기분이 '전체'가 아닌 경우, && 해당 기분에 맞는 일기만 필터링하여 표시
- 선택한 기분의 일기기록이 없을 때 react-hot-toast를 사용하여 일기가 없다는 알림을 띄움.
![image](https://github.com/user-attachments/assets/7b0c22fa-bd5a-4cdf-8e63-845f9d118eff)

  <br />

### 🔧 앞으로의 과제


  <br />

### 이슈

<!-- 이슈 키워드와 함께 #을 입력한 후 이슈 번호를 선택해주세요. -->
<!-- 에시 : resolves #1 -->

resolves #147 
