### PR TITLE
refactor: FeelingCalendar 컴포넌트에 loading 상태 추가 및 Calendar 컴포넌트로 렌더링 책임 이관

### DIFF
--- a/src/components/home/Calendar.jsx
+++ b/src/components/home/Calendar.jsx
@@ -1,6 +1,7 @@
 import { useCalendar } from '@/hooks';
 import { format } from 'date-fns';
 import PropTypes from 'prop-types';
+import FeelingCalendar from './FeelingCalendar';
 
 const WEEKS = ['일', '월', '화', '수', '목', '금', '토'];
 
@@ -8,8 +9,14 @@ const Calendar = ({
   diaryData = [],
   selectedMonth = format(new Date(), 'yyyy-MM'),
   selectedMood,
+  loading,
 }) => {
-  const { weekRows } = useCalendar(diaryData, selectedMonth, selectedMood);
+  const { weekRows } = useCalendar(
+    diaryData,
+    selectedMonth,
+    selectedMood,
+    loading
+  );
 
   return (
     <table className="w-full border-separate border-spacing-y-5 border-spacing-x-0">
@@ -25,7 +32,22 @@ const Calendar = ({
       </thead>
       <tbody>
         {weekRows.map((week) => (
-          <tr key={week.key}>{week.days.map((day) => day.component)}</tr>
+          <tr key={week.key}>
+            {week.days.map((day) => (
+              <td key={day.key}>
+                {day.isCurrentMonth ? (
+                  <FeelingCalendar
+                    day={parseInt(format(day.day, 'd'), 10)}
+                    mood={day.mood}
+                    date={day.date}
+                    id={day.id}
+                    hasDiaryWithDifferentMood={day.hasDiaryWithDifferentMood}
+                    loading={loading}
+                  />
+                ) : null}
+              </td>
+            ))}
+          </tr>
         ))}
       </tbody>
     </table>
@@ -36,6 +58,7 @@ Calendar.propTypes = {
   diaryData: PropTypes.array,
   selectedMonth: PropTypes.string,
   selectedMood: PropTypes.string,
+  loading: PropTypes.bool,
 };
 
 export default Calendar;

--- a/src/components/home/FeelingCalendar.jsx
+++ b/src/components/home/FeelingCalendar.jsx
@@ -11,6 +11,7 @@ const FeelingCalendar = ({
   date,
   id,
   hasDiaryWithDifferentMood,
+  loading,
 }) => {
   const hasDiaryWithDifferentMoodClasses = `${
     hasDiaryWithDifferentMood
@@ -21,6 +22,12 @@ const FeelingCalendar = ({
   const handleClick = (e) => {
     const selectedDate = format(new Date(date), 'yyyy-MM-dd');
     const currentDate = format(new Date(), 'yyyy-MM-dd');
+
+    if (loading) {
+      e.preventDefault();
+      toast.error('데이터를 불러오는 중입니다. 잠시만 기다려주세요!');
+      return;
+    }
 
     if (currentDate < selectedDate) {
       e.preventDefault();
@@ -53,6 +60,7 @@ FeelingCalendar.propTypes = {
   id: PropTypes.string,
   date: PropTypes.string,
   hasDiaryWithDifferentMood: PropTypes.bool,
+  loading: PropTypes.bool,
 };
 
 export default FeelingCalendar;

--- a/src/hooks/useCalendar.jsx
+++ b/src/hooks/useCalendar.jsx
@@ -1,4 +1,3 @@
-import { FeelingCalendar } from '@/components';
 import {
   addDays,
   format,
@@ -47,13 +46,17 @@ const useCalendar = (
 
       for (let dayIdx = 0; dayIdx < 7; dayIdx++) {
         const day = addDays(firstDayOfCalendar, weekIdx * 7 + dayIdx);
+        const formattedDate = format(day, 'yyyy-MM-dd');
 
         if (getMonth(day) !== month) {
-          days.push({ key: dayIdx, component: <td key={dayIdx}></td> });
+          days.push({
+            key: dayIdx,
+            date: formattedDate,
+            isCurrentMonth: false,
+          });
           continue;
         }
 
-        const formattedDate = format(day, 'yyyy-MM-dd');
         const dayDiary = diaryData.find(
           (diary) => diary.date === formattedDate
         );
@@ -62,17 +65,12 @@ const useCalendar = (
 
         days.push({
           key: dayIdx,
-          component: (
-            <td key={dayIdx}>
-              <FeelingCalendar
-                day={parseInt(format(day, 'd'), 10)}
-                mood={dayDiary ? dayDiary.mood : undefined}
-                date={formattedDate}
-                id={dayDiary ? dayDiary.id : ''}
-                hasDiaryWithDifferentMood={hasDiaryWithDifferentMood}
-              />
-            </td>
-          ),
+          day,
+          isCurrentMonth: true,
+          mood: dayDiary ? dayDiary.mood : undefined,
+          date: formattedDate,
+          id: dayDiary ? dayDiary.id : '',
+          hasDiaryWithDifferentMood,
         });
       }
 
@@ -88,6 +86,8 @@ const useCalendar = (
 useCalendar.propTypes = {
   diaryData: PropTypes.array,
   selectedMonth: PropTypes.string,
+  selectedMood: PropTypes.string,
+  loading: PropTypes.bool,
 };
 
 export default useCalendar;

--- a/src/pages/Home.jsx
+++ b/src/pages/Home.jsx
@@ -43,7 +43,7 @@ const Home = ({ viewMode: initialViewMode }) => {
         duration: 3000,
       });
     }
-  }, [selectedMood, filteredMoodData.length]);
+  }, [selectedMood, filteredMoodData]);
 
   const handleToggleView = () => {
     const newViewMode = viewMode === 'calendar' ? 'list' : 'calendar';
@@ -54,11 +54,6 @@ const Home = ({ viewMode: initialViewMode }) => {
   const handleDiaryDelete = (id) => {
     setDiaryData((prevData) => prevData.filter((diary) => diary.id !== id));
   };
-
-  if (loading) {
-    console.log('로딩 중..');
-    // 추후 로딩 처리 로직을 가져오거나..등
-  }
 
   return (
     <>
@@ -89,11 +84,17 @@ const Home = ({ viewMode: initialViewMode }) => {
           setSelectedMonth={setSelectedMonth}
           className="py-5"
         />
-        {viewMode === 'calendar' ? (
+        {loading ? (
+          /* 임시 처리임 - 추후 로딩 스피너나 다른 UI로 변경할 것 */
+          <p className="mt-5 font-semibold text-center text-blue-500">
+            로딩 중입니다... ⏳
+          </p>
+        ) : viewMode === 'calendar' ? (
           <Calendar
             diaryData={diaryData}
             selectedMonth={selectedMonth}
             selectedMood={selectedMood}
+            loading={loading}
           />
         ) : (
           <main className="flex flex-col gap-5">


### PR DESCRIPTION
### 제목 : refactor: FeelingCalendar 컴포넌트에 loading 상태 추가 및 Calendar 컴포넌트로 렌더링 책임 이관

### PR 유형

- [ ] 새로운 기능 추가
- [x] 버그 수정
- [ ] CSS 등 사용자 UI 디자인 변경
- [ ] 코드에 영향을 주지 않는 변경사항(오타 수정, 탭 사이즈 변경, 변수명 변경)
- [x] 코드 리팩토링
- [ ] 주석 추가 및 수정
- [ ] 문서 수정
- [ ] 테스트 추가, 테스트 리팩토링
- [ ] 빌드 부분 혹은 패키지 매니저 수정
- [ ] 파일 혹은 폴더명 수정
- [ ] 파일 혹은 폴더 삭제

### PR 체크리스트

<!-- PR이 다음 요구 사항을 충족하는지 확인하세요. -->

- [x] 커밋 메시지 컨벤션에 맞게 작성했습니다.
- [ ] 변경 사항에 대한 테스트를 했습니다.(버그 수정/기능에 대한 테스트).

### 🔎 작업 내용

<!-- 어떤 작업을 하셨는지 상세하게 작성해주세요-->

- FeelingCalendar 컴포넌트에 loading 상태 추가 및 사용 (미해결)
- 💥해당 문제 아직 미해결 됨 (팀에게 내용 전달 함)
  - Calendar 컴포넌트에서 FeelingCalendar로 loading 상태를 전달받아 클릭 시 처리.
  - 미래의 일기 기록을 막기 위한 로직과 데이터 로딩 중일 때 클릭을 막기 위한 로직 추가.
  - 로딩 상태가 진행 중일 때 사용자에게 알림을 제공하도록 개선

- useCalendar 훅에서 렌더링 책임 분리
- Calendar 컴포넌트로 FeelingCalendar 렌더링 책임 이관

  <br />

### 🔧 앞으로의 과제

- 로딩 관련 이슈 해결하기..
- 로딩 페이지 UI 
  <br />

### 이슈

<!-- 이슈 키워드와 함께 #을 입력한 후 이슈 번호를 선택해주세요. -->
<!-- 에시 : resolves #1 -->

resolves #211 
