### PR TITLE
refactor: NewDiary 페이지에서 새로고침/뒤로가기 제어 및 useBlocker훅 추가

### DIFF
--- a/src/components/common/Modal.jsx
+++ b/src/components/common/Modal.jsx
@@ -1,20 +1,22 @@
-import { memo } from 'react';
 import PropTypes from 'prop-types';
+import { memo } from 'react';
 import { IoClose } from 'react-icons/io5';
 
-const Modal = ({ isOpen, closeModal, children }) => {
+const Modal = ({ isOpen, closeModal, children, showCloseButton = true }) => {
   if (!isOpen) return null;
 
   return (
     <div className="fixed inset-0 flex items-center justify-center bg-black bg-opacity-30 z-[1000] backdrop-blur-[1px]">
       <div className="relative w-full max-w-[400px] p-4 bg-white rounded-lg shadow-lg">
-        <button
-          onClick={closeModal}
-          type="button"
-          className="absolute top-[18px] right-5"
-        >
-          <IoClose aria-hidden={true} className="w-6 h-6" color="#393939" />
-        </button>
+        {showCloseButton && (
+          <button
+            onClick={closeModal}
+            type="button"
+            className="absolute top-[18px] right-5"
+          >
+            <IoClose aria-hidden={true} className="w-6 h-6" color="#393939" />
+          </button>
+        )}
         {children}
       </div>
     </div>
@@ -25,6 +27,7 @@ Modal.propTypes = {
   isOpen: PropTypes.bool.isRequired,
   closeModal: PropTypes.func.isRequired,
   children: PropTypes.node,
+  showCloseButton: PropTypes.bool,
 };
 
 export default memo(Modal);

--- a/src/components/layouts/TopHeader.jsx
+++ b/src/components/layouts/TopHeader.jsx
@@ -3,11 +3,15 @@ import PropTypes from 'prop-types';
 import { useNavigate } from 'react-router-dom';
 import { memo } from 'react';
 
-const TopHeader = ({ title, isShowIcon = false }) => {
+const TopHeader = ({ title, isShowIcon = false, onBackClick }) => {
   const navigate = useNavigate();
 
   const handleBackClick = () => {
-    navigate(-1);
+    if (onBackClick) {
+      onBackClick();
+    } else {
+      navigate(-1);
+    }
   };
 
   return (
@@ -30,6 +34,7 @@ const TopHeader = ({ title, isShowIcon = false }) => {
 TopHeader.propTypes = {
   title: PropTypes.string.isRequired,
   isShowIcon: PropTypes.bool,
+  onBackClick: PropTypes.func,
 };
 
 export default memo(TopHeader);

--- a/src/components/layouts/TopHeader.jsx
+++ b/src/components/layouts/TopHeader.jsx
@@ -3,15 +3,11 @@ import PropTypes from 'prop-types';
 import { useNavigate } from 'react-router-dom';
 import { memo } from 'react';
 
-const TopHeader = ({ title, isShowIcon = false, onBackClick }) => {
+const TopHeader = ({ title, isShowIcon = false }) => {
   const navigate = useNavigate();
 
   const handleBackClick = () => {
-    if (onBackClick) {
-      onBackClick();
-    } else {
-      navigate(-1);
-    }
+    navigate(-1);
   };
 
   return (

--- a/src/components/layouts/TopHeader.jsx
+++ b/src/components/layouts/TopHeader.jsx
@@ -1,7 +1,7 @@
 import { DirectionLeft } from '@/assets/icons/direction';
 import PropTypes from 'prop-types';
-import { useNavigate } from 'react-router-dom';
 import { memo } from 'react';
+import { useNavigate } from 'react-router-dom';
 
 const TopHeader = ({ title, isShowIcon = false }) => {
   const navigate = useNavigate();
@@ -30,7 +30,6 @@ const TopHeader = ({ title, isShowIcon = false }) => {
 TopHeader.propTypes = {
   title: PropTypes.string.isRequired,
   isShowIcon: PropTypes.bool,
-  onBackClick: PropTypes.func,
 };
 
 export default memo(TopHeader);

--- a/src/hooks/index.js
+++ b/src/hooks/index.js
@@ -5,3 +5,4 @@ export { default as useFetchDiaryDetail } from './useFetchDiaryDetail.jsx';
 export { default as useFetchMonthlyDiaryData } from './useFetchMonthlyDiaryData.jsx';
 export { default as useFetchAllBuddyData } from './useFetchAllBuddyData.jsx';
 export { default as useCheckAvailability } from './useCheckAvailability.jsx';
+export { default as useBlocker } from './useBlocker.jsx';

--- a/src/hooks/useBlocker.jsx
+++ b/src/hooks/useBlocker.jsx
@@ -13,10 +13,17 @@ const useBlocker = (when, alertOptions) => {
   const currentLocation = useLocation();
   const { isOpen, openModal, closeModal } = useModal();
 
+  // 새로고침 방지를 위한 beforeunload 이벤트 핸들러
+  const handleBeforeUnload = useCallback((e) => {
+    e.preventDefault();
+    e.returnValue = ''; // 경고 메시지 표시
+  }, []);
+
   const handleProceed = useCallback(() => {
     proceed();
     closeModal('confirmLeave');
-  }, [proceed, closeModal]);
+    window.removeEventListener('beforeunload', handleBeforeUnload);
+  }, [proceed, closeModal, handleBeforeUnload]);
 
   const handleReset = useCallback(() => {
     reset();
@@ -33,6 +40,18 @@ const useBlocker = (when, alertOptions) => {
       window.removeEventListener('beforeunload', handleBeforeUnload);
     };
   }, [when, state, currentLocation, nextLocation]);
+
+  useEffect(() => {
+    if (when) {
+      window.addEventListener('beforeunload', handleBeforeUnload);
+    } else {
+      window.removeEventListener('beforeunload', handleBeforeUnload);
+    }
+
+    return () => {
+      window.removeEventListener('beforeunload', handleBeforeUnload);
+    };
+  }, [when, handleBeforeUnload]);
 
   useEffect(() => {
     if (state === 'blocked') {

--- a/src/hooks/useBlocker.jsx
+++ b/src/hooks/useBlocker.jsx
@@ -1,0 +1,79 @@
+import { useEffect, useCallback } from 'react';
+import { useBlocker as useBlockerCore, useLocation } from 'react-router-dom';
+import useModal from './useModal';
+import { Button, Modal } from '@/components';
+
+const useBlocker = (when, alertOptions) => {
+  const {
+    state,
+    location: nextLocation,
+    reset,
+    proceed,
+  } = useBlockerCore(when);
+  const currentLocation = useLocation();
+  const { isOpen, openModal, closeModal } = useModal();
+
+  const handleProceed = useCallback(() => {
+    proceed();
+    closeModal('confirmLeave');
+  }, [proceed, closeModal]);
+
+  const handleReset = useCallback(() => {
+    reset();
+    closeModal('confirmLeave');
+  }, [reset, closeModal]);
+
+  useEffect(() => {
+    const handleBeforeUnload = (e) => {
+      e.preventDefault();
+      e.returnValue = '';
+    };
+
+    return () => {
+      window.removeEventListener('beforeunload', handleBeforeUnload);
+    };
+  }, [when, state, currentLocation, nextLocation]);
+
+  useEffect(() => {
+    if (state === 'blocked') {
+      openModal('confirmLeave');
+    } else {
+      closeModal('confirmLeave');
+    }
+  }, [state, openModal, closeModal]);
+
+  const renderPrompt = useCallback(
+    () => (
+      <Modal
+        isOpen={isOpen('confirmLeave')}
+        closeModal={handleReset}
+        showCloseButton={false}
+      >
+        <div className="flex flex-col gap-5">
+          <p className="text-center whitespace-pre-wrap">
+            {alertOptions?.message}
+          </p>
+          <div className="flex items-center justify-center w-full gap-3">
+            <Button
+              type="secondary"
+              text="취소"
+              onClick={handleReset}
+              className="flex-1"
+            />
+            <Button
+              type="primary"
+              text="뒤로가기"
+              onClick={handleProceed}
+              className="flex-1"
+            />
+          </div>
+        </div>
+      </Modal>
+    ),
+    [alertOptions?.message, isOpen, handleProceed, handleReset]
+  );
+
+  return { state, reset, proceed, renderPrompt };
+};
+
+export default useBlocker;

--- a/src/hooks/useBlocker.jsx
+++ b/src/hooks/useBlocker.jsx
@@ -50,7 +50,7 @@ const useBlocker = (when, alertOptions) => {
         showCloseButton={false}
       >
         <div className="flex flex-col gap-5">
-          <p className="text-center whitespace-pre-wrap">
+          <p className="font-medium text-center text-gray-500 whitespace-pre-wrap">
             {alertOptions?.message}
           </p>
           <div className="flex items-center justify-center w-full gap-3">
@@ -59,12 +59,14 @@ const useBlocker = (when, alertOptions) => {
               text="취소"
               onClick={handleReset}
               className="flex-1"
+              aria-label="취소"
             />
             <Button
               type="primary"
               text="뒤로가기"
               onClick={handleProceed}
               className="flex-1"
+              aria-label="이전 페이지로 가기"
             />
           </div>
         </div>

--- a/src/hooks/useBlocker.jsx
+++ b/src/hooks/useBlocker.jsx
@@ -16,7 +16,7 @@ const useBlocker = (when, alertOptions) => {
   // 새로고침 방지를 위한 beforeunload 이벤트 핸들러
   const handleBeforeUnload = useCallback((e) => {
     e.preventDefault();
-    e.returnValue = ''; // 경고 메시지 표시
+    e.returnValue = '';
   }, []);
 
   const handleProceed = useCallback(() => {

--- a/src/pages/diary/NewDiary.jsx
+++ b/src/pages/diary/NewDiary.jsx
@@ -4,31 +4,26 @@ import weathers from '@/assets/icons/weather/weathers';
 import {
   Accordion,
   Button,
-  Modal,
   SelectMood,
   SelectPicture,
   TextArea,
   TopHeader,
   WeatherWithIcon,
 } from '@/components';
-import { useFetchDiaryDetail, useModal } from '@/hooks';
+import { useFetchDiaryDetail } from '@/hooks';
 import { format } from 'date-fns';
-import { useCallback, useEffect, useState } from 'react';
+import { useEffect, useState, useCallback } from 'react';
 import toast from 'react-hot-toast';
-import {
-  useNavigate,
-  useLocation,
-  unstable_usePrompt as usePrompt,
-} from 'react-router-dom';
+import { useLocation, useNavigate } from 'react-router-dom';
+import useBlocker from '@/hooks/useBlocker'; // useBlocker 훅을 가져옵니다
 
 const baseImageUrl = `${import.meta.env.VITE_PB_API}/files/diary`;
-const MODAL_MESSAGE = `작성 중인 내용이 저장되지 않아요. \n페이지를 벗어나시겠습니까?`;
+const BLOCK_MESSAGE = `작성 중인 내용이 저장되지 않아요. \n페이지를 벗어나시겠습니까?`;
 
 export const Component = () => {
   const navigate = useNavigate();
   const location = useLocation();
   const { date, diaryId } = location.state || {};
-  const { openModal, closeModal, isOpen } = useModal();
 
   const userId = JSON.parse(localStorage.getItem('auth')).user.id;
   const defaultTitle = date || format(new Date(), 'yyyy-MM-dd');
@@ -38,7 +33,6 @@ export const Component = () => {
   const [selectedWeathers, setSelectedWeathers] = useState([]);
   const [text, setText] = useState('');
   const [picture, setPicture] = useState(null);
-  const [isBlocking, setIsBlocking] = useState(false);
 
   const { diaryDetail } = useFetchDiaryDetail(diaryId);
 
@@ -54,7 +48,6 @@ export const Component = () => {
     }
   }, [diaryDetail]);
 
-  // 사용자가 인풋 입력이나 감정 등 선택을 했는지 확인
   const isAnyInputMade = useCallback(() => {
     return (
       selectedMood !== null ||
@@ -63,27 +56,11 @@ export const Component = () => {
       text.trim() !== '' ||
       picture !== null
     );
-  }, [
-    picture,
-    selectedMood,
-    selectedEmotions.length,
-    selectedWeathers.length,
-    text,
-  ]);
+  }, [selectedMood, selectedEmotions, selectedWeathers, text, picture]);
 
-  useEffect(() => {
-    setIsBlocking(isAnyInputMade());
-  }, [
-    selectedMood,
-    selectedEmotions,
-    selectedWeathers,
-    text,
-    picture,
-    isAnyInputMade,
-  ]);
-
-  // 페이지 벗어남을 감지하여 경고 메시지 띄우기
-  usePrompt(MODAL_MESSAGE, isBlocking);
+  const { renderPrompt } = useBlocker(isAnyInputMade, {
+    message: `${BLOCK_MESSAGE}`,
+  });
 
   const handleEmotionClick = (text) => {
     if (selectedEmotions.includes(text)) {
@@ -145,7 +122,6 @@ export const Component = () => {
           : '일기 작성에 실패했습니다...',
       })
       .then(() => {
-        setIsBlocking(false); // 탐색 차단 해제
         navigate('/');
       })
       .catch((error) => {
@@ -153,35 +129,11 @@ export const Component = () => {
       });
   };
 
-  const handleBackClick = () => {
-    if (isAnyInputMade()) {
-      openModal('confirmLeave');
-    } else {
-      navigate(-1);
-    }
-  };
-
-  const handleCancel = () => {
-    closeModal('confirmLeave');
-  };
-
-  const handleConfirmLeave = () => {
-    closeModal('confirmLeave');
-    setIsBlocking(false); // 탐색 차단 해제
-    navigate(-1);
-  };
-
   return (
     <section className="flex flex-col gap-5 pb-[100px]">
-      <TopHeader
-        title={defaultTitle}
-        isShowIcon={true}
-        onBackClick={handleBackClick}
-      />
-      <form
-        className="flex flex-col gap-5 overflow-y-hidden"
-        onSubmit={handleSubmit}
-      >
+      <TopHeader title={defaultTitle} isShowIcon={true} />
+      {renderPrompt()} {/* 차단된 상태일 때 경고 메시지 표시 */}
+      <form className="flex flex-col gap-5" onSubmit={handleSubmit}>
         <SelectMood isSelected={selectedMood} setSelected={setSelectedMood} />
         <Accordion open={true} title="감정" className="grid grid-cols-5 gap-4">
           {Object.entries(emotions).map(([key, src]) => (
@@ -215,28 +167,6 @@ export const Component = () => {
           />
         </footer>
       </form>
-
-      <Modal isOpen={isOpen('confirmLeave')} closeModal={handleCancel}>
-        <div className="flex flex-col gap-5">
-          <p className="text-center whitespace-pre-wrap">{MODAL_MESSAGE}</p>
-          <div className="flex items-center justify-center w-full gap-3">
-            <Button
-              type="secondary"
-              className="flex-1"
-              onClick={handleCancel}
-              text="취소"
-              aria-label="취소"
-            />
-            <Button
-              type="primary"
-              className="flex-1"
-              onClick={handleConfirmLeave}
-              text="뒤로가기"
-              aria-label="뒤로 가기"
-            />
-          </div>
-        </div>
-      </Modal>
     </section>
   );
 };

--- a/src/pages/diary/NewDiary.jsx
+++ b/src/pages/diary/NewDiary.jsx
@@ -10,8 +10,7 @@ import {
   TopHeader,
   WeatherWithIcon,
 } from '@/components';
-import { useFetchDiaryDetail } from '@/hooks';
-import useBlocker from '@/hooks/useBlocker';
+import { useFetchDiaryDetail, useBlocker } from '@/hooks';
 import { format } from 'date-fns';
 import { useCallback, useEffect, useState } from 'react';
 import toast from 'react-hot-toast';

--- a/src/pages/diary/NewDiary.jsx
+++ b/src/pages/diary/NewDiary.jsx
@@ -48,6 +48,7 @@ export const Component = () => {
     }
   }, [diaryDetail]);
 
+  // 사용자가 인풋 입력 or 아이콘 선택을 했는지 확인
   const isAnyInputMade = useCallback(() => {
     return (
       selectedMood !== null ||

--- a/src/pages/diary/NewDiary.jsx
+++ b/src/pages/diary/NewDiary.jsx
@@ -11,11 +11,11 @@ import {
   WeatherWithIcon,
 } from '@/components';
 import { useFetchDiaryDetail } from '@/hooks';
+import useBlocker from '@/hooks/useBlocker';
 import { format } from 'date-fns';
-import { useEffect, useState, useCallback } from 'react';
+import { useCallback, useEffect, useState } from 'react';
 import toast from 'react-hot-toast';
 import { useLocation, useNavigate } from 'react-router-dom';
-import useBlocker from '@/hooks/useBlocker'; // useBlocker 훅을 가져옵니다
 
 const baseImageUrl = `${import.meta.env.VITE_PB_API}/files/diary`;
 const BLOCK_MESSAGE = `작성 중인 내용이 저장되지 않아요. \n페이지를 벗어나시겠습니까?`;

--- a/src/styles/main.css
+++ b/src/styles/main.css
@@ -12,9 +12,15 @@
 }
 
 /* 글로벌 폰트 적용 */
+/* 전체 화면에서 세로 스크롤 비활성화 */
 body {
   height: 100%;
   font-family: 'Pretendard', sans-serif;
+
+  -ms-overflow-style: none;
+}
+::-webkit-scrollbar {
+  display: none;
 }
 
 #root {

--- a/src/styles/main.css
+++ b/src/styles/main.css
@@ -12,15 +12,9 @@
 }
 
 /* 글로벌 폰트 적용 */
-/* 전체 화면에서 세로 스크롤 비활성화 */
 body {
   height: 100%;
   font-family: 'Pretendard', sans-serif;
-
-  -ms-overflow-style: none;
-}
-::-webkit-scrollbar {
-  display: none;
 }
 
 #root {
@@ -31,7 +25,7 @@ body {
   min-height: 100dvh;
   margin: 0 auto;
   padding: 0 20px;
-  background-color: #F1F5FA;
+  background-color: #f1f5fa;
 }
 
 summary::-webkit-details-marker {


### PR DESCRIPTION
### 제목 : refactor: NewDiary 페이지에서 새로고침/뒤로가기 제어 및 useBlocker훅 추가

### PR 유형

- [x] 새로운 기능 추가
- [ ] 버그 수정
- [ ] CSS 등 사용자 UI 디자인 변경
- [ ] 코드에 영향을 주지 않는 변경사항(오타 수정, 탭 사이즈 변경, 변수명 변경)
- [x] 코드 리팩토링
- [ ] 주석 추가 및 수정
- [ ] 문서 수정
- [ ] 테스트 추가, 테스트 리팩토링
- [ ] 빌드 부분 혹은 패키지 매니저 수정
- [ ] 파일 혹은 폴더명 수정
- [ ] 파일 혹은 폴더 삭제

### PR 체크리스트

<!-- PR이 다음 요구 사항을 충족하는지 확인하세요. -->

- [x] 커밋 메시지 컨벤션에 맞게 작성했습니다.
- [ ] 변경 사항에 대한 테스트를 했습니다.(버그 수정/기능에 대한 테스트).

### 🔎 작업 내용

<!-- 어떤 작업을 하셨는지 상세하게 작성해주세요-->

- useBlocker.jsx 훅 추가 
  - 사용자가 뒤로가기를 클릭 시 (브라우저 창 && TopHeader의 뒤로가기 버튼) 경고 모달 띄우기
![image](https://github.com/user-attachments/assets/e5c1ee91-9b25-49ad-bc37-501b35a54cfe)
  - 새로고침 누를 경우 브라우저 에서 새로고침 할건지 확인
![image](https://github.com/user-attachments/assets/537bf7ae-2a42-465f-b60c-0a99c39736d9)
 

- 감정 / 날씨 / input / 사진 중 아무것도 선택하거나 입력하지 않은 경우에는 바로 뒤로가기 처리됨
- 하나라도 입력 / 선택 했을 경우 뒤로가기 제어 == 경고 모달 띄움

<br />

- 기존 모달 컴포넌트에는 닫기 - ❌ 버튼이 항상 포함되어있는 형태 였으나,
 NewDiary에선 취소버튼으로 닫기 처리가 되어 해당 버튼이 필요가 없어짐
![image](https://github.com/user-attachments/assets/a59b7787-c18e-488b-b5ea-bfb156bb2a1e)
-  showCloseButton  prop을 추가하여 닫기 버튼의 렌더링을 조건부로 처리할 수 있도록 함
![image](https://github.com/user-attachments/assets/087b099a-0c1e-4db5-90de-dca9720df0e4)

  
  <br />

### 🔧 앞으로의 과제

- 💡 작성 페이지 글을 작성 후 메인으로 이동됨 
  - 이후 다시 뒤로가기 누르면 방금 작성한 날짜의 신규 일기 작성페이지로 또 이동하게 됩니당.  이 부분에 대한 얘기 나누어야 함. 
  - 일기 중복 작성 건..
  
  <br />

### 이슈

<!-- 이슈 키워드와 함께 #을 입력한 후 이슈 번호를 선택해주세요. -->
<!-- 에시 : resolves #1 -->

resolves #219 
