### PR TITLE
bugfix: 일기 작성 페이지 뒤로가기, 새로고침 관련 경고 삭제

### DIFF
--- a/src/hooks/useFetchDiaryDetail.jsx
+++ b/src/hooks/useFetchDiaryDetail.jsx
@@ -8,12 +8,12 @@ const useFetchDiaryDetail = (diaryId) => {
   const navigate = useNavigate();
 
   useEffect(() => {
+    if (!diaryId) {
+      return;
+    }
+
     const getData = async () => {
       try {
-        if (!diaryId) {
-          return;
-        }
-
         const record = await pb.collection('diary').getOne(diaryId);
 
         setDiaryDetail({

--- a/src/pages/diary/NewDiary.jsx
+++ b/src/pages/diary/NewDiary.jsx
@@ -9,19 +9,15 @@ import {
   TopHeader,
   WeatherWithIcon,
 } from '@/components';
-import { useFetchDiaryDetail, useDiaryActions, useBlocker } from '@/hooks';
+import { useFetchDiaryDetail, useDiaryActions } from '@/hooks';
 import { format } from 'date-fns';
-import { useCallback } from 'react';
 import { useLocation } from 'react-router-dom';
-
-const BLOCK_MESSAGE =
-  '`작성 중인 내용이 저장되지 않아요. \n페이지를 벗어나시겠습니까?`';
 
 export const Component = () => {
   const location = useLocation();
   const { date, diaryId } = location.state || {};
 
-  const defaultTitle = date || format(new Date(), 'yyyy-MM-dd');
+  const currentDate = date || format(new Date(), 'yyyy-MM-dd');
 
   const { diaryDetail } = useFetchDiaryDetail(diaryId);
 
@@ -37,26 +33,11 @@ export const Component = () => {
     handleEmotionClick,
     handleWeatherClick,
     handleSubmit,
-  } = useDiaryActions(diaryDetail, defaultTitle, diaryId);
-
-  const isAnyInputMade = useCallback(() => {
-    return (
-      selectedMood !== null ||
-      selectedEmotions.length > 0 ||
-      selectedWeathers.length > 0 ||
-      text.trim() !== '' ||
-      picture !== null
-    );
-  }, [selectedMood, selectedEmotions, selectedWeathers, text, picture]);
-
-  const { renderPrompt } = useBlocker(isAnyInputMade, {
-    message: `${BLOCK_MESSAGE}`,
-  });
+  } = useDiaryActions(diaryDetail, currentDate, diaryId);
 
   return (
     <section className="flex flex-col gap-5 pb-[100px]">
-      <TopHeader title={defaultTitle} isShowIcon={true} />
-      {renderPrompt()} {/* 차단된 상태일 때 경고 메시지 표시 */}
+      <TopHeader title={currentDate} isShowIcon={true} />
       <form className="flex flex-col gap-5" onSubmit={handleSubmit}>
         <SelectMood isSelected={selectedMood} setSelected={setSelectedMood} />
         <Accordion open={true} title="감정" className="grid grid-cols-5 gap-4">


### PR DESCRIPTION
### 제목 : feat(248): 일기 작성 페이지 뒤로가기, 새로고침 관련 경고 삭제

### PR 유형

- [ ] 새로운 기능 추가
- [x] 버그 수정
- [ ] CSS 등 사용자 UI 디자인 변경
- [ ] 코드에 영향을 주지 않는 변경사항(오타 수정, 탭 사이즈 변경, 변수명 변경)
- [ ] 코드 리팩토링
- [ ] 주석 추가 및 수정
- [ ] 문서 수정
- [ ] 테스트 추가, 테스트 리팩토링
- [ ] 빌드 부분 혹은 패키지 매니저 수정
- [ ] 파일 혹은 폴더명 수정
- [ ] 파일 혹은 폴더 삭제

### PR 체크리스트

<!-- PR이 다음 요구 사항을 충족하는지 확인하세요. -->

- [ ] 커밋 메시지 컨벤션에 맞게 작성했습니다.
- [ ] 변경 사항에 대한 테스트를 했습니다.(버그 수정/기능에 대한 테스트).

### 🔎 작업 내용

<!-- 어떤 작업을 하셨는지 상세하게 작성해주세요-->

- 일기 작성 페이지 뒤로가기, 새로고침 관련 경고 삭제
  <br />

### 🔧 앞으로의 과제

- 일단 유진님이 작성하신 훅 파일은 그대로 둔채 작성 다이어리 페이지 안의 로직안에서만 훅 기능을 뺐습니다. 추후에 관련 로직 리팩토링을 한 뒤 기능을 추가 해야할 것 같습니다.
  <br />

### 이슈

<!-- 이슈 키워드와 함께 #을 입력한 후 이슈 번호를 선택해주세요. -->
<!-- 에시 : resolves #1 -->

resolves #248
