### PR TITLE
modify : 단짝관리 페이지 로딩문구 및 데이터가 없을 때 문구 스타일링 추가 & 단짝 1일 전인 경우 n시간으로 표시될 수 있도록 수정

### DIFF
--- a/src/components/buddy/BuddyCard.jsx
+++ b/src/components/buddy/BuddyCard.jsx
@@ -1,14 +1,13 @@
 import { PropTypes } from 'prop-types';
-import { differenceInDays, format } from 'date-fns';
+import { differenceInDays, differenceInHours } from 'date-fns';
 import { memo } from 'react';
 import pb from '@/api/pb';
 import toast from 'react-hot-toast';
 
 const BuddyCard = ({ buddyName, startDate, buddyId, onDelete }) => {
-  const daysDifference = differenceInDays(
-    format(new Date(), 'yyyy-MM-dd'),
-    startDate
-  );
+  const hoursDifference = differenceInHours(new Date(), new Date(startDate));
+
+  const daysDifference = differenceInDays(new Date(), new Date(startDate));
 
   const handleDelete = async () => {
     try {
@@ -30,7 +29,11 @@ const BuddyCard = ({ buddyName, startDate, buddyId, onDelete }) => {
     <div className="flex justify-between bg-white py-[13px] px-[18px] rounded-[14px] shadow-light items-center">
       <p className="text-lg font-medium">{buddyName}</p>
       <div className="flex flex-row gap-[15px] items-center">
-        <p className="font-medium text-gray-300">{`${daysDifference}일 째 단짝 중`}</p>
+        <p className="font-medium text-gray-300">
+          {hoursDifference < 24
+            ? `${hoursDifference}시간 째 단짝 중`
+            : `${daysDifference}일 째 단짝 중`}
+        </p>
         <button
           type="button"
           aria-label={`${buddyName}님과 절교 `}

--- a/src/pages/mypage/BuddyManagement.jsx
+++ b/src/pages/mypage/BuddyManagement.jsx
@@ -17,29 +17,30 @@ const BuddyManagement = () => {
     );
   }, []);
 
-  if (loading) {
-    return <p>로딩중...</p>;
-  }
-
   return (
     <section className="min-h-dvh pb-[80px]">
       <TopHeader title="단짝 관리" isShowIcon={true}></TopHeader>
       <main className="flex flex-col gap-5 mt-5">
         <h2 className="sr-only">단짝 리스트</h2>
-
-        {buddies.length > 0 ? (
-          buddies.map(({ buddyName, created, buddyId }) => (
-            <BuddyCard
-              key={buddyId}
-              buddyName={buddyName}
-              startDate={format(new Date(created), 'yyyy-MM-dd')}
-              buddyId={buddyId}
-              onDelete={handleDelete}
-            />
-          ))
-        ) : (
-          <p>단짝이 없습니다..!</p>
+        {loading && (
+          <p className="font-medium text-center text-gray-300">
+            단짝 데이터 불러오는 중...
+          </p>
         )}
+        {buddies.length === 0 && !loading && (
+          <p className="font-medium text-center text-gray-300">
+            아직 단짝이 존재하지 않아요!
+          </p>
+        )}
+        {buddies.map(({ buddyName, created, buddyId }) => (
+          <BuddyCard
+            key={buddyId}
+            buddyName={buddyName}
+            startDate={format(new Date(created), 'yyyy-MM-dd')}
+            buddyId={buddyId}
+            onDelete={handleDelete}
+          />
+        ))}
       </main>
     </section>
   );

--- a/src/pages/mypage/BuddyManagement.jsx
+++ b/src/pages/mypage/BuddyManagement.jsx
@@ -1,7 +1,7 @@
 import { useState, useEffect, useCallback } from 'react';
 import { BuddyCard, TopHeader } from '@/components';
 import { useFetchAllBuddyData } from '@/hooks';
-import { format } from 'date-fns';
+import { formatDate } from 'date-fns';
 
 const BuddyManagement = () => {
   const { buddyData, loading } = useFetchAllBuddyData();
@@ -36,7 +36,7 @@ const BuddyManagement = () => {
           <BuddyCard
             key={buddyId}
             buddyName={buddyName}
-            startDate={format(new Date(created), 'yyyy-MM-dd')}
+            startDate={formatDate(created, 'yyyy-MM-dd HH:mm:ss')}
             buddyId={buddyId}
             onDelete={handleDelete}
           />


### PR DESCRIPTION
### 제목 : 
modify : 단짝관리 페이지 로딩문구 및 데이터가 없을 때 문구 스타일링 추가 & 단짝 1일 전인 경우 n시간으로 표시될 수 있도록 수정

### PR 유형

- [ ] 새로운 기능 추가
- [ ] 버그 수정
- [ ] CSS 등 사용자 UI 디자인 변경
- [ ] 코드에 영향을 주지 않는 변경사항(오타 수정, 탭 사이즈 변경, 변수명 변경)
- [x] 코드 리팩토링
- [ ] 주석 추가 및 수정
- [ ] 문서 수정
- [ ] 테스트 추가, 테스트 리팩토링
- [ ] 빌드 부분 혹은 패키지 매니저 수정
- [ ] 파일 혹은 폴더명 수정
- [ ] 파일 혹은 폴더 삭제

### PR 체크리스트

<!-- PR이 다음 요구 사항을 충족하는지 확인하세요. -->

- [x] 커밋 메시지 컨벤션에 맞게 작성했습니다.
- [ ] 변경 사항에 대한 테스트를 했습니다.(버그 수정/기능에 대한 테스트).

### 🔎 작업 내용

<!-- 어떤 작업을 하셨는지 상세하게 작성해주세요-->

- 단짝 관리 페이지 로딩 문구 및 데이터 없을 때 문구 스타일링 추가
- buddyCard에서 시간차이도 계산하여, 24시간 미만은 n시간 쨰 단짝중으로 표시될 수 있도록 수정
  <br />

### 구현 이미지
![image](https://github.com/user-attachments/assets/cf1a86a1-50f3-4340-9593-1ab885a01e85)


### 이슈

resolves #231
