### PR TITLE
bugfix : 모달창 esc 키 눌렀을 때 '닫기' 기능 추가

### DIFF
--- a/src/components/common/Modal.jsx
+++ b/src/components/common/Modal.jsx
@@ -1,8 +1,25 @@
 import PropTypes from 'prop-types';
-import { memo } from 'react';
+import { memo, useEffect } from 'react';
 import { IoClose } from 'react-icons/io5';
 
 const Modal = ({ isOpen, closeModal, children, showCloseButton = true }) => {
+  // ESC 버튼을 누를 경우 모달 창 닫기
+  useEffect(() => {
+    const handleKeyDown = (e) => {
+      if (e.key === 'Escape') {
+        closeModal();
+      }
+    };
+
+    if (isOpen) {
+      window.addEventListener('keydown', handleKeyDown);
+    }
+
+    return () => {
+      window.removeEventListener('keydown', handleKeyDown);
+    };
+  }, [isOpen, closeModal]);
+
   if (!isOpen) return null;
 
   return (


### PR DESCRIPTION
### 제목 : 
bugfix : 모달창 esc 키 눌렀을 때 '닫기' 기능 추가

### PR 유형

- [ ] 새로운 기능 추가
- [x] 버그 수정
- [ ] CSS 등 사용자 UI 디자인 변경
- [ ] 코드에 영향을 주지 않는 변경사항(오타 수정, 탭 사이즈 변경, 변수명 변경)
- [ ] 코드 리팩토링
- [ ] 주석 추가 및 수정
- [ ] 문서 수정
- [ ] 테스트 추가, 테스트 리팩토링
- [ ] 빌드 부분 혹은 패키지 매니저 수정
- [ ] 파일 혹은 폴더명 수정
- [ ] 파일 혹은 폴더 삭제

### PR 체크리스트

<!-- PR이 다음 요구 사항을 충족하는지 확인하세요. -->

- [x] 커밋 메시지 컨벤션에 맞게 작성했습니다.
- [ ] 변경 사항에 대한 테스트를 했습니다.(버그 수정/기능에 대한 테스트).

### 🔎 작업 내용

- 모달창이 열려 있을 때만, 이벤트가 작동하여 esc 버튼을 누르면 모달창이 닫힘.
  <br />

### 이슈

resolves #241
