### PR TITLE
feat: 로딩 스피너 컴포넌트 추가 및 캘린더에 적용

### DIFF
--- a/package.json
+++ b/package.json
@@ -21,6 +21,7 @@
     "react-hot-toast": "^2.4.1",
     "react-icons": "^5.3.0",
     "react-router-dom": "^6.26.1",
+    "react-spinners": "^0.14.1",
     "zustand": "^4.5.5"
   },
   "devDependencies": {

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -41,6 +41,9 @@ importers:
       react-router-dom:
         specifier: ^6.26.1
         version: 6.26.1(react-dom@18.3.1(react@18.3.1))(react@18.3.1)
+      react-spinners:
+        specifier: ^0.14.1
+        version: 0.14.1(react-dom@18.3.1(react@18.3.1))(react@18.3.1)
       zustand:
         specifier: ^4.5.5
         version: 4.5.5(@types/react@18.3.4)(react@18.3.1)
@@ -1588,6 +1591,12 @@ packages:
     engines: {node: '>=14.0.0'}
     peerDependencies:
       react: '>=16.8'
+
+  react-spinners@0.14.1:
+    resolution: {integrity: sha512-2Izq+qgQ08HTofCVEdcAQCXFEYfqTDdfeDQJeo/HHQiQJD4imOicNLhkfN2eh1NYEWVOX4D9ok2lhuDB0z3Aag==}
+    peerDependencies:
+      react: ^16.0.0 || ^17.0.0 || ^18.0.0
+      react-dom: ^16.0.0 || ^17.0.0 || ^18.0.0
 
   react@18.3.1:
     resolution: {integrity: sha512-wS+hAgJShR0KhEvPJArfuPVN1+Hz1t0Y6n5jLrGQbkb4urgPE/0Rve+1kMB1v/oWgHgm4WIcV+i7F2pTVj+2iQ==}
@@ -3434,6 +3443,11 @@ snapshots:
     dependencies:
       '@remix-run/router': 1.19.1
       react: 18.3.1
+
+  react-spinners@0.14.1(react-dom@18.3.1(react@18.3.1))(react@18.3.1):
+    dependencies:
+      react: 18.3.1
+      react-dom: 18.3.1(react@18.3.1)
 
   react@18.3.1:
     dependencies:

--- a/src/components/common/LoadingSpinner.jsx
+++ b/src/components/common/LoadingSpinner.jsx
@@ -1,0 +1,17 @@
+import PropTypes from 'prop-types';
+import { SyncLoader } from 'react-spinners';
+
+const LoadingSpinner = ({ text }) => {
+  return (
+    <div className="fixed flex flex-col items-center gap-8 transform -translate-x-1/2 -translate-y-1/2 top-1/2 left-1/2">
+      <SyncLoader color="#4D82BE" size={14} margin={4} />
+      <p className="font-medium text-gray-400">{text}</p>
+    </div>
+  );
+};
+
+LoadingSpinner.propTypes = {
+  text: PropTypes.string,
+};
+
+export default LoadingSpinner;

--- a/src/components/home/Calendar.jsx
+++ b/src/components/home/Calendar.jsx
@@ -19,7 +19,7 @@ const Calendar = ({
   );
 
   return (
-    <table className="w-full border-separate border-spacing-y-5 border-spacing-x-0">
+    <table className="w-full border-separate border-spacing-y-5">
       <caption className="sr-only">일기 달력</caption>
       <thead>
         <tr>

--- a/src/components/index.js
+++ b/src/components/index.js
@@ -12,6 +12,8 @@ export { default as YearMonth } from './common/YearMonth.jsx';
 export { default as CheckBox } from './common/CheckBox.jsx';
 export { default as BuddyListModal } from './common/BuddyListModal.jsx';
 export { default as ConfirmModal } from './common/ConfirmModal';
+export { default as LoadingSpinner } from './common/LoadingSpinner.jsx';
+
 // home
 export { default as Calendar } from './home/Calendar.jsx';
 export { default as FeelingCalendar } from './home/FeelingCalendar.jsx';

--- a/src/pages/Home.jsx
+++ b/src/pages/Home.jsx
@@ -1,5 +1,11 @@
-import { Calendar, DiaryCard, TopNavigation, YearMonth } from '@/components';
-import { useFetchMonthlyDiaryData, useFetchAllBuddyData } from '@/hooks';
+import {
+  Calendar,
+  DiaryCard,
+  LoadingSpinner,
+  TopNavigation,
+  YearMonth,
+} from '@/components';
+import { useFetchAllBuddyData, useFetchMonthlyDiaryData } from '@/hooks';
 import { format } from 'date-fns';
 import PropTypes from 'prop-types';
 import { useEffect, useMemo, useState } from 'react';
@@ -86,10 +92,7 @@ const Home = ({ viewMode: initialViewMode }) => {
           className="py-5"
         />
         {loading ? (
-          /* 임시 처리임 - 추후 로딩 스피너나 다른 UI로 변경할 것 */
-          <p className="mt-5 font-semibold text-center text-blue-500">
-            로딩 중입니다... ⏳
-          </p>
+          <LoadingSpinner text="일기를 불러오고 있어요" />
         ) : viewMode === 'calendar' ? (
           <Calendar
             diaryData={diaryData}


### PR DESCRIPTION
### 제목 : feat: 로딩 스피너 추가 및 캘린더에 적용

### PR 유형

- [x] 새로운 기능 추가
- [ ] 버그 수정
- [ ] CSS 등 사용자 UI 디자인 변경
- [ ] 코드에 영향을 주지 않는 변경사항(오타 수정, 탭 사이즈 변경, 변수명 변경)
- [ ] 코드 리팩토링
- [ ] 주석 추가 및 수정
- [ ] 문서 수정
- [ ] 테스트 추가, 테스트 리팩토링
- [ ] 빌드 부분 혹은 패키지 매니저 수정
- [ ] 파일 혹은 폴더명 수정
- [ ] 파일 혹은 폴더 삭제

### PR 체크리스트

<!-- PR이 다음 요구 사항을 충족하는지 확인하세요. -->

- [x] 커밋 메시지 컨벤션에 맞게 작성했습니다.
- [ ] 변경 사항에 대한 테스트를 했습니다.(버그 수정/기능에 대한 테스트).

### 🔎 작업 내용

<!-- 어떤 작업을 하셨는지 상세하게 작성해주세요-->

- 로딩중 UI를 위한 react-spinners 라이브러리 설치
-  LoadingSpinners 컴포넌트 생성
   - 재사용 가능하도록 로딩중 문구를 props로 받도록 함
  <br />
  
스피너 위치를 어디에 둘까 하다가 일단 중앙에 fixed로 위치시켰습니당 (우측)
확인 부탁드립니당
![image](https://github.com/user-attachments/assets/cb28d6d3-d2ef-404c-b5c7-790f621f0e61)



  <br />

### 이슈

<!-- 이슈 키워드와 함께 #을 입력한 후 이슈 번호를 선택해주세요. -->
<!-- 에시 : resolves #1 -->

resolves #229 
