### PR TITLE
bugfix: 일기 작성 중복 방지 로직 전체 수정

### DIFF
--- a/src/components/layouts/Footer.jsx
+++ b/src/components/layouts/Footer.jsx
@@ -2,40 +2,11 @@ import { Calendar, Chart, Letter, Pencil, User } from '@/assets/icons/gnb';
 import { useLocation } from 'react-router-dom';
 import { Link } from 'react-router-dom';
 import { memo } from 'react';
-import { pb } from '@/api';
-import { authUtils } from '@/utils';
-import { format } from 'date-fns';
-import { useNavigate } from 'react-router-dom';
-import toast from 'react-hot-toast';
 
 const Footer = () => {
-  const navigate = useNavigate();
-
   const currentUrl = useLocation().pathname;
   const getLinkClassName = (path) => {
     return currentUrl.startsWith(path) ? 'fill-blue-500' : 'fill-gray-300';
-  };
-
-  const handleWriteDiary = async (e) => {
-    e.preventDefault();
-
-    const userId = authUtils.getAuth().user.id;
-    const date = format(new Date(), 'yyyy-MM-dd');
-
-    try {
-      const data = await pb.collection('diary').getFullList({
-        filter: `user = "${userId}" && date = "${date} 00:00:00.000Z"`,
-      });
-
-      if (data.length > 0) {
-        toast.dismiss();
-        toast.error('오늘 일기는 이미 작성하셨습니다.');
-        return;
-      }
-    } catch (error) {
-      console.error('서버 통신중 에러 발생', error);
-    }
-    navigate('/diary/new');
   };
 
   return (
@@ -48,7 +19,7 @@ const Footer = () => {
         <Link to={'/chart'} title="통계">
           <Chart className={`cursor-pointer ${getLinkClassName('/chart')}`} />
         </Link>
-        <Link to={'/diary/new'} onClick={handleWriteDiary} title="일기작성">
+        <Link to={'/diary/new'} title="일기작성">
           <Pencil className="cursor-pointer fill-gray-300" />
         </Link>
         <Link to={'/post'} title="우편함">

--- a/src/hooks/useDiaryActions.js
+++ b/src/hooks/useDiaryActions.js
@@ -59,7 +59,7 @@ const useDiaryActions = (diaryDetail, defaultTitle, diaryId) => {
   );
 
   const handleSubmit = useCallback(
-    (e) => {
+    async (e) => {
       e.preventDefault();
 
       if (
@@ -71,6 +71,20 @@ const useDiaryActions = (diaryDetail, defaultTitle, diaryId) => {
         toast.dismiss();
         toast.error('입력하지 않은 필수 값이 있습니다.');
         return;
+      }
+
+      try {
+        const data = await pb.collection('diary').getFullList({
+          filter: `user = "${userId}" && date = "${defaultTitle} 00:00:00.000Z"`,
+        });
+
+        if (data.length > 0) {
+          toast.dismiss();
+          toast.error('오늘 일기는 이미 작성하셨습니다.');
+          return;
+        }
+      } catch (error) {
+        console.error('서버 통신중 에러 발생', error);
       }
 
       const formData = new FormData();


### PR DESCRIPTION
### 제목 : feat(240): 일기 작성 중복 방지 로직 전체 수정

### PR 유형

- [ ] 새로운 기능 추가
- [x] 버그 수정
- [ ] CSS 등 사용자 UI 디자인 변경
- [ ] 코드에 영향을 주지 않는 변경사항(오타 수정, 탭 사이즈 변경, 변수명 변경)
- [x] 코드 리팩토링
- [ ] 주석 추가 및 수정
- [ ] 문서 수정
- [ ] 테스트 추가, 테스트 리팩토링
- [ ] 빌드 부분 혹은 패키지 매니저 수정
- [ ] 파일 혹은 폴더명 수정
- [ ] 파일 혹은 폴더 삭제

### PR 체크리스트

<!-- PR이 다음 요구 사항을 충족하는지 확인하세요. -->

- [x] 커밋 메시지 컨벤션에 맞게 작성했습니다.
- [x] 변경 사항에 대한 테스트를 했습니다.(버그 수정/기능에 대한 테스트).

### 🔎 작업 내용

<!-- 어떤 작업을 하셨는지 상세하게 작성해주세요-->
- GNB 에서 일기작성 버튼을 눌렀을때 서버 통신해서 작성했는지 확인 했던점을 일기 작성 폼 안에서 제출할때 검사하도록 변경
- 위 처럼 로직을 바꾼 이유는 페이지 뒤로가기 했을때도 중복 작성을 방지해야하기 때문에 여러번의 데이터 통신은 불필요하다고 판단
  <br />

### 🔧 앞으로의 과제

- 내일 할 일을 적어주세요
  <br />

### 이슈

<!-- 이슈 키워드와 함께 #을 입력한 후 이슈 번호를 선택해주세요. -->
<!-- 에시 : resolves #1 -->

resolves #240
