### PR TITLE
refactor: 일기 상세페이지 교환된 일기일 경우 수정, 삭제, 교환 버튼 표시 안되도록 수정

### DIFF
--- a/src/components/common/DiaryDetail.jsx
+++ b/src/components/common/DiaryDetail.jsx
@@ -46,37 +46,26 @@ const DiaryDetail = ({ diaryDetail, exchange = false }) => {
       <article className="w-full bg-white rounded-[10px] shadow-light p-[0.9375rem] mt-[30px] ">
         <h2 className="sr-only">{`${weekday}요일 감정 일기`}</h2>
         <div className="flex justify-end gap-[15px]">
-          {!exchange ? (
-            <Link
-              to="/diary/new"
-              state={{ date: diaryDetail.date, diaryId: diaryDetail.id }}
-              aria-label="일기 수정"
-              title="일기 수정"
-            >
-              <Edit className="w-5 h-5 fill-gray-400" aria-hidden="true" />
-            </Link>
-          ) : (
-            <span
-              className="w-5 h-5 cursor-not-allowed fill-gray-400"
-              aria-label="일기 수정"
-              title="일기 수정"
-            >
-              <Edit className="w-5 h-5 fill-gray-400" aria-hidden="true" />
-            </span>
+          {!exchange && (
+            <>
+              <Link
+                to="/diary/new"
+                state={{ date: diaryDetail.date, diaryId: diaryDetail.id }}
+                aria-label="일기 수정"
+                title="일기 수정"
+              >
+                <Edit className="w-5 h-5 fill-gray-400" aria-hidden="true" />
+              </Link>
+
+              <button type="button" aria-label="일기 삭제" title="일기 삭제">
+                <Delete
+                  className="w-5 h-5 fill-gray-400"
+                  aria-hidden="true"
+                  onClick={() => openModal('deleteModal')}
+                />
+              </button>
+            </>
           )}
-          <button
-            className={`${exchange && 'cursor-not-allowed'}`}
-            type="button"
-            aria-label="일기 삭제"
-            title="일기 삭제"
-            disabled={exchange}
-          >
-            <Delete
-              className="w-5 h-5 fill-gray-400"
-              aria-hidden="true"
-              onClick={() => openModal('deleteModal')}
-            />
-          </button>
         </div>
 
         <div className="flex flex-col gap-y-5">
@@ -128,15 +117,15 @@ const DiaryDetail = ({ diaryDetail, exchange = false }) => {
           )}
         </div>
       </article>
-      <footer className="fixed bottom-0 w-full max-w-[27.5rem] bg-white py-4 z-50 shadow-top -mx-5 px-5">
-        <Button
-          className={`${exchange && 'cursor-not-allowed'}`}
-          text="교환하기"
-          size="large"
-          onClick={() => openModal('buddyListModal')}
-          disabled={exchange}
-        />
-      </footer>
+      {!exchange && (
+        <footer className="fixed bottom-0 w-full max-w-[27.5rem] bg-white py-4 z-50 shadow-top -mx-5 px-5">
+          <Button
+            text="교환하기"
+            size="large"
+            onClick={() => openModal('buddyListModal')}
+          />
+        </footer>
+      )}
       <ConfirmModal
         isOpen={isOpen('deleteModal')}
         closeModal={() => closeModal('deleteModal')}


### PR DESCRIPTION
### 제목 : feat(268): 일기 상세페이지 교환된 일기일 경우 수정, 삭제, 교환 버튼 표시 안되도록 수정

### PR 유형

- [ ] 새로운 기능 추가
- [ ] 버그 수정
- [ ] CSS 등 사용자 UI 디자인 변경
- [ ] 코드에 영향을 주지 않는 변경사항(오타 수정, 탭 사이즈 변경, 변수명 변경)
- [x] 코드 리팩토링
- [ ] 주석 추가 및 수정
- [ ] 문서 수정
- [ ] 테스트 추가, 테스트 리팩토링
- [ ] 빌드 부분 혹은 패키지 매니저 수정
- [ ] 파일 혹은 폴더명 수정
- [ ] 파일 혹은 폴더 삭제

### PR 체크리스트

<!-- PR이 다음 요구 사항을 충족하는지 확인하세요. -->

- [x] 커밋 메시지 컨벤션에 맞게 작성했습니다.
- [x] 변경 사항에 대한 테스트를 했습니다.(버그 수정/기능에 대한 테스트).

### 🔎 작업 내용

<!-- 어떤 작업을 하셨는지 상세하게 작성해주세요-->
- 일기 상세페이지 교환된 일기일 경우 수정, 삭제, 교환 버튼 표시 안되도록 수정
  <br />

### 🔧 앞으로의 과제

- 내일 할 일을 적어주세요
  <br />

### 이슈

<!-- 이슈 키워드와 함께 #을 입력한 후 이슈 번호를 선택해주세요. -->
<!-- 에시 : resolves #1 -->

resolves #268
