### PR TITLE
refactor: 일기 검색 페이지에서 검색어를 URL 파라미터로 전달하도록 로직 수정

### DIFF
--- a/src/components/searchdiary/SearchDiaryInput.jsx
+++ b/src/components/searchdiary/SearchDiaryInput.jsx
@@ -1,7 +1,7 @@
 import { DirectionLeft } from '@/assets/icons/direction';
 import { Close, Search } from '@/assets/icons/menu';
 import PropTypes from 'prop-types';
-import { useNavigate } from 'react-router-dom';
+import { useNavigate, useSearchParams } from 'react-router-dom';
 
 const SearchDiaryInput = ({
   inputValue,
@@ -12,8 +12,17 @@ const SearchDiaryInput = ({
 }) => {
   const navigate = useNavigate();
 
+  const [searchParams] = useSearchParams();
+  const query = searchParams.get('query');
+
   const handleBackClick = () => {
-    navigate('/');
+    if (query) {
+      setInputValue('');
+      setSearchResults({});
+      navigate('/home/search', { replace: true });
+    } else {
+      navigate('/');
+    }
   };
 
   const handleChange = (e) => {

--- a/src/hooks/index.js
+++ b/src/hooks/index.js
@@ -7,3 +7,4 @@ export { default as useFetchAllBuddyData } from './useFetchAllBuddyData.jsx';
 export { default as useCheckAvailability } from './useCheckAvailability.jsx';
 export { default as useBlocker } from './useBlocker.jsx';
 export { default as useDiaryActions } from './useDiaryActions';
+export { default as useSearchDiary } from './useSearchDiary.js';

--- a/src/hooks/useSearchDiary.js
+++ b/src/hooks/useSearchDiary.js
@@ -1,0 +1,95 @@
+import { useFetchAllBuddyData, useFetchAllDiaryData } from '@/hooks';
+import { groupByMonth } from '@/utils';
+import { useCallback, useEffect, useState } from 'react';
+import { useSearchParams } from 'react-router-dom';
+
+const useSearchDiary = () => {
+  const { diaryData, loading } = useFetchAllDiaryData();
+  const { buddyData } = useFetchAllBuddyData();
+
+  const [searchParams, setSearchParams] = useSearchParams();
+  const [inputValue, setInputValue] = useState('');
+  const [searchResults, setSearchResults] = useState({});
+  const [isSearched, setIsSearched] = useState(false);
+  const [history, setHistory] = useState(() => {
+    const savedHistory = localStorage.getItem('searchHistory');
+    return savedHistory ? JSON.parse(savedHistory) : [];
+  });
+
+  useEffect(() => {
+    localStorage.setItem('searchHistory', JSON.stringify(history));
+  }, [history]);
+
+  const handleAddHistory = (term) => {
+    if (term === '') return;
+    setHistory((prevHistory) => {
+      const updatedHistory = prevHistory.filter((item) => item !== term);
+      updatedHistory.unshift(term);
+      if (updatedHistory.length > 10) {
+        updatedHistory.pop();
+      }
+      return updatedHistory;
+    });
+  };
+
+  const handleClearHistory = () => {
+    setHistory([]);
+    localStorage.removeItem('searchHistory');
+  };
+
+  const handleDeleteHistoryItem = (itemToDelete) => {
+    setHistory((prevHistory) =>
+      prevHistory.filter((item) => item !== itemToDelete)
+    );
+  };
+
+  const handleDiarySearch = useCallback(
+    (searchTerm) => {
+      if (searchTerm && !loading) {
+        const result = diaryData.filter((diary) =>
+          diary.content.includes(searchTerm)
+        );
+
+        const groupedResults = groupByMonth(result);
+        setSearchResults(groupedResults);
+        setIsSearched(true);
+        handleAddHistory(searchTerm);
+
+        setSearchParams({ query: searchTerm });
+      } else {
+        setSearchResults({});
+      }
+    },
+    [diaryData, loading, setSearchParams]
+  );
+
+  useEffect(() => {
+    const searchTerm = searchParams.get('query');
+    if (searchTerm) {
+      setInputValue(searchTerm);
+      if (!loading) handleDiarySearch(searchTerm, false);
+    }
+  }, [searchParams, loading, handleDiarySearch]);
+
+  const handleHistoryItemClick = (historyItem) => {
+    setInputValue(historyItem);
+    handleDiarySearch(historyItem);
+  };
+
+  return {
+    inputValue,
+    setInputValue,
+    searchResults,
+    setSearchResults,
+    isSearched,
+    setIsSearched,
+    history,
+    handleClearHistory,
+    handleDeleteHistoryItem,
+    handleDiarySearch,
+    handleHistoryItemClick,
+    buddyData,
+  };
+};
+
+export default useSearchDiary;

--- a/src/pages/SearchDiary.jsx
+++ b/src/pages/SearchDiary.jsx
@@ -3,87 +3,23 @@ import {
   SearchDiaryInput,
   SearchDiaryResult,
 } from '@/components';
-import { useFetchAllBuddyData, useFetchAllDiaryData } from '@/hooks';
-import { groupByMonth } from '@/utils';
-import { useCallback, useEffect, useState } from 'react';
-import { useSearchParams } from 'react-router-dom';
+import { useSearchDiary } from '@/hooks';
 
 const SearchDiary = () => {
-  const { diaryData, loading } = useFetchAllDiaryData();
-  const { buddyData } = useFetchAllBuddyData();
-
-  const [searchParams, setSearchParams] = useSearchParams();
-
-  const [inputValue, setInputValue] = useState('');
-  const [searchResults, setSearchResults] = useState({});
-  const [isSearched, setIsSearched] = useState(false);
-  const [history, setHistory] = useState(() => {
-    const savedHistory = localStorage.getItem('searchHistory');
-    return savedHistory ? JSON.parse(savedHistory) : [];
-  });
-
-  useEffect(() => {
-    localStorage.setItem('searchHistory', JSON.stringify(history));
-  }, [history]);
-
-  const handleAddHistory = (term) => {
-    if (term === '') return;
-    setHistory((prevHistory) => {
-      const updatedHistory = prevHistory.filter((item) => item !== term);
-
-      updatedHistory.unshift(term);
-
-      if (updatedHistory.length > 10) {
-        updatedHistory.pop();
-      }
-      return updatedHistory;
-    });
-  };
-
-  const handleClearHistory = () => {
-    setHistory([]);
-    localStorage.removeItem('searchHistory');
-  };
-
-  const handleDeleteHistoryItem = (itemToDelete) => {
-    setHistory((prevHistory) =>
-      prevHistory.filter((item) => item !== itemToDelete)
-    );
-  };
-
-  const handleDiarySearch = useCallback(
-    (searchTerm) => {
-      if (searchTerm && !loading) {
-        const result = diaryData.filter((diary) =>
-          diary.content.includes(searchTerm)
-        );
-
-        const groupedResults = groupByMonth(result);
-        setSearchResults(groupedResults);
-        setIsSearched(true);
-        handleAddHistory(searchTerm);
-
-        setSearchParams({ query: searchTerm });
-      } else {
-        setSearchResults({});
-      }
-    },
-    [diaryData, loading, setSearchParams]
-  );
-
-  useEffect(() => {
-    const searchTerm = searchParams.get('query');
-    if (searchTerm) {
-      setInputValue(searchTerm);
-
-      if (!loading) handleDiarySearch(searchTerm, false);
-    }
-  }, [searchParams, loading, handleDiarySearch]);
-
-  const handleHistoryItemClick = (historyItem) => {
-    setInputValue(historyItem);
-    handleDiarySearch(historyItem);
-  };
+  const {
+    inputValue,
+    setInputValue,
+    searchResults,
+    setSearchResults,
+    isSearched,
+    setIsSearched,
+    history,
+    handleClearHistory,
+    handleDeleteHistoryItem,
+    handleDiarySearch,
+    handleHistoryItemClick,
+    buddyData,
+  } = useSearchDiary();
 
   return (
     <section className="pb-[60px]">

--- a/src/pages/diary/DetailDiary.jsx
+++ b/src/pages/diary/DetailDiary.jsx
@@ -1,7 +1,7 @@
-import { DiaryDetail, TopHeader } from '@/components';
+import { DiaryDetail, LoadingSpinner, TopHeader } from '@/components';
 import { useFetchDiaryDetail } from '@/hooks';
 import { useEffect, useState } from 'react';
-import { useParams, useLocation } from 'react-router-dom';
+import { useLocation, useParams } from 'react-router-dom';
 
 export const Component = () => {
   const { id } = useParams();
@@ -17,13 +17,7 @@ export const Component = () => {
   }, [diaryDetail]);
 
   if (loading) {
-    return (
-      <div className="flex items-center justify-center min-h-dvh">
-        <p className="font-medium text-gray-300 ">
-          하루몽이 일기를 가져오고 있어요...
-        </p>
-      </div>
-    );
+    return <LoadingSpinner text="하루몽이 일기를 가져오고 있어요" />;
   }
 
   if (!diaryDate) return;


### PR DESCRIPTION
### 제목 : refactor: 일기 검색 페이지에서 검색어를 URL 파라미터로 전달하도록 로직 수정

### PR 유형

- [ ] 새로운 기능 추가
- [ ] 버그 수정
- [ ] CSS 등 사용자 UI 디자인 변경
- [ ] 코드에 영향을 주지 않는 변경사항(오타 수정, 탭 사이즈 변경, 변수명 변경)
- [x] 코드 리팩토링
- [ ] 주석 추가 및 수정
- [ ] 문서 수정
- [ ] 테스트 추가, 테스트 리팩토링
- [ ] 빌드 부분 혹은 패키지 매니저 수정
- [ ] 파일 혹은 폴더명 수정
- [ ] 파일 혹은 폴더 삭제

### PR 체크리스트

<!-- PR이 다음 요구 사항을 충족하는지 확인하세요. -->

- [x] 커밋 메시지 컨벤션에 맞게 작성했습니다.
- [ ] 변경 사항에 대한 테스트를 했습니다.(버그 수정/기능에 대한 테스트).

### 🔎 작업 내용

<!-- 어떤 작업을 하셨는지 상세하게 작성해주세요-->

- 일기 검색 화면에서 사용자가 검색어를 입력한 후 일기 상세 화면으로 이동했다가 뒤로가기 했을 때, 검색어가 초기화되고 있던 현상을 검색어를 파라미터로 전달하며 해결함.
-  검색한 검색어가 뒤로가기해도 그대로 유지됨.
- 일기 검색 페이지 로직 분리

💡💡💡
뒤로가기 클릭 시,
1) 파라미터가 없는 경우 /home/search로 이동 
2) 쿼리 파라미터가 있는 경우에는 해당 쿼리 를 검색하는 로직인데
- TopHeader의 뒤로가기 버튼 클릭 시에는 원하는대로 작동하나
- 브라우저 뒤로가기 클릭 시에는 원하는 대로 작동하지 않음. 확인 필요함.

  <br />


### 이슈

<!-- 이슈 키워드와 함께 #을 입력한 후 이슈 번호를 선택해주세요. -->
<!-- 에시 : resolves #1 -->

resolves #243 
