### PR TITLE
modify : 닉네임 변경 모달 중복으로 설정된 패딩 값 삭제

### DIFF
--- a/src/pages/mypage/MyPageSetting.jsx
+++ b/src/pages/mypage/MyPageSetting.jsx
@@ -162,7 +162,7 @@ const MypageSetting = () => {
         isOpen={isOpen('nicknameModal')}
         closeModal={() => closeModal('nicknameModal')}
       >
-        <div className="flex flex-col gap-4 p-4">
+        <div className="flex flex-col gap-4">
           <h3 className="text-lg font-semibold">닉네임 변경</h3>
           {/* 라벨 추가 */}
           <label className="sr-only" htmlFor="nickname-input">

--- a/src/pages/mypage/MyPageSetting.jsx
+++ b/src/pages/mypage/MyPageSetting.jsx
@@ -17,9 +17,27 @@ const MypageSetting = () => {
   // 기능관련
   const [isNicknameAvailable, setIsNicknameAvailable] = useState(null);
   const [isLoading, setIsLoading] = useState(false);
+  const [isDisabled, setIsDisabled] = useState(false);
 
   // 모달관련
   const { isOpen, openModal, closeModal } = useModal();
+
+  // 모달이 닫힐 때 setIsDisabled 초기화
+  useEffect(() => {
+    if (!isOpen('nicknameModal')) {
+      setIsDisabled(false);
+      setNewNickname('');
+      setIsNicknameAvailable(null);
+    }
+  }, [isOpen('nicknameModal')]);
+
+  // 닉네임 입력이 변경되면 중복확인 상태를 초기화
+  useEffect(() => {
+    if (newNickname) {
+      setIsNicknameAvailable(null);
+      setIsDisabled(false);
+    }
+  }, [newNickname]);
 
   // 위치 상태에서 닉네임을 설정합니다.
   useEffect(() => {
@@ -43,8 +61,9 @@ const MypageSetting = () => {
 
   // 닉네임 수정
   const handleUpdateNickname = useCallback(async () => {
+    toast.dismiss();
     if (!isNicknameAvailable) {
-      toast.error('이미 존재하는 닉네임이에요!');
+      toast.error('닉네임 중복 확인을 먼저 해주세요!');
       return;
     }
 
@@ -73,6 +92,7 @@ const MypageSetting = () => {
 
   // 닉네임 중복 확인
   const checkNicknameAvailability = useCallback(async () => {
+    toast.dismiss();
     if (!newNickname.trim()) {
       toast.error('닉네임을 입력해주세요!');
       return;
@@ -88,6 +108,7 @@ const MypageSetting = () => {
       if (error.status === 404) {
         setIsNicknameAvailable(true);
         toast.success('사용 가능한 닉네임이에요!');
+        setIsDisabled(true);
       } else {
         toast.error('닉네임 확인 중 오류가 발생했어요!');
       }
@@ -162,30 +183,39 @@ const MypageSetting = () => {
         isOpen={isOpen('nicknameModal')}
         closeModal={() => closeModal('nicknameModal')}
       >
-        <div className="flex flex-col gap-4">
+        <div className="flex flex-col w-full gap-3">
           <h3 className="text-lg font-semibold">닉네임 변경</h3>
           {/* 라벨 추가 */}
-          <label className="sr-only" htmlFor="nickname-input">
-            새 닉네임 입력
-          </label>
-          <input
-            type="text"
-            value={newNickname}
-            onChange={(e) => setNewNickname(e.target.value)}
-            className="p-2 border border-gray-300 rounded-md"
-            placeholder="새 닉네임 입력"
-            aria-label="새 닉네임 입력"
-            id="nickname-input"
-          />
-          <button
-            onClick={checkNicknameAvailability}
-            className="p-2 text-white bg-gray-300 rounded-md"
-          >
-            닉네임 중복 확인
-          </button>
+          <div className="flex flex-row justify-between gap-1">
+            <label className="sr-only" htmlFor="nickname-input">
+              새 닉네임 입력
+            </label>
+            <input
+              type="text"
+              value={newNickname}
+              onChange={(e) => setNewNickname(e.target.value)}
+              className="flex-1 p-2 border border-gray-300 rounded-md"
+              placeholder="새 닉네임 입력"
+              aria-label="새 닉네임 입력"
+              id="nickname-input"
+            />
+            <button
+              onClick={checkNicknameAvailability}
+              className={`flex-1 p-1 text-white ${
+                isDisabled ? 'bg-gray-300' : 'bg-blue-500'
+              } rounded-md`}
+              disabled={isDisabled}
+            >
+              중복 확인
+            </button>
+          </div>
           <button
             onClick={handleUpdateNickname}
-            className="p-2 text-white bg-blue-500 rounded-md"
+            className={`p-2 text-white ${
+              isLoading || isNicknameAvailable === false
+                ? 'bg-gray-300'
+                : 'bg-blue-500'
+            } rounded-md`}
             disabled={isLoading || isNicknameAvailable === false}
           >
             {isLoading ? '업데이트 중...' : '닉네임 변경'}


### PR DESCRIPTION
### 제목 : 
modify : 닉네임 변경 모달 중복으로 설정된 패딩 값 삭제

### PR 유형

- [ ] 새로운 기능 추가
- [ ] 버그 수정
- [x] CSS 등 사용자 UI 디자인 변경
- [ ] 코드에 영향을 주지 않는 변경사항(오타 수정, 탭 사이즈 변경, 변수명 변경)
- [x] 코드 리팩토링
- [ ] 주석 추가 및 수정
- [ ] 문서 수정
- [ ] 테스트 추가, 테스트 리팩토링
- [ ] 빌드 부분 혹은 패키지 매니저 수정
- [ ] 파일 혹은 폴더명 수정
- [ ] 파일 혹은 폴더 삭제

### PR 체크리스트

<!-- PR이 다음 요구 사항을 충족하는지 확인하세요. -->

- [x] 커밋 메시지 컨벤션에 맞게 작성했습니다.
- [ ] 변경 사항에 대한 테스트를 했습니다.(버그 수정/기능에 대한 테스트).

### 🔎 작업 내용

- 닉네임 변경 모달 창 -> 패딩값 중복으로 설정된 부분 코드 삭제
- 닉네임 변경 모달 3층에서 2층으로 스타일링 수정
- '중복 확인' 버튼 -> 사용 가능한 닉네임이면 disabled되고, 회색으로 색상 변경
- '닉네임 변경' 버튼 -> 활성화 되면 blue, 비활성화 상태면 gray 색상으로 나타나도록 변경
- 닉네임 인풋값 변경될 때마다 중복확인 상태 초기화
  <br />

### 구현이미지

* 기본 상태
![image](https://github.com/user-attachments/assets/f8b6b80a-f3f9-4a6a-a1bd-578fd271c9ed)

* 닉네임 중복일 때 -> 닉네임 변경 버튼 비활성화
![image](https://github.com/user-attachments/assets/27898b9e-100b-411b-ba4e-aadf8b355e79)

* 닉네임 중복 아닐 때 -> 중복확인 버튼 비활성화, 닉네임 변경 버튼 활성화
![image](https://github.com/user-attachments/assets/1fe295a7-4879-4003-b147-5fe3eb7751d1)



### 이슈
resolves #256
