### PR TITLE
modify : 교환일기 수락할 때 일기가 많으면 일기를 스크롤할 수 있도록 스타일 수정

### DIFF
--- a/src/pages/Notification.jsx
+++ b/src/pages/Notification.jsx
@@ -172,16 +172,18 @@ const Notification = () => {
         isOpen={isOpen('diaryListModal')}
         closeModal={() => closeModal('diaryListModal')}
       >
-        <div className="flex flex-col gap-4">
+        <div className="flex flex-col gap-4 max-h-[50vh]">
           <h2 className="text-lg font-semibold text-gray-500">일기 리스트</h2>
-          {diaryData.map((diary, idx) => (
-            <CheckBox
-              key={diary.id}
-              label={diary.date}
-              checked={checkedIndex === idx}
-              onChange={() => handleChange(diary.id, idx)}
-            />
-          ))}
+          <div className="flex flex-col gap-2 overflow-y-auto">
+            {diaryData.map((diary, idx) => (
+              <CheckBox
+                key={diary.id}
+                label={diary.date}
+                checked={checkedIndex === idx}
+                onChange={() => handleChange(diary.id, idx)}
+              />
+            ))}
+          </div>
           <button
             type="button"
             className="py-2 font-medium text-white rounded-md bg-blue"


### PR DESCRIPTION
### 제목 : 
modify : 교환일기 수락할 때 일기가 많으면 일기를 스크롤할 수 있도록 스타일 수정

### PR 유형

- [ ] 새로운 기능 추가
- [ ] 버그 수정
- [x] CSS 등 사용자 UI 디자인 변경
- [ ] 코드에 영향을 주지 않는 변경사항(오타 수정, 탭 사이즈 변경, 변수명 변경)
- [ ] 코드 리팩토링
- [ ] 주석 추가 및 수정
- [ ] 문서 수정
- [ ] 테스트 추가, 테스트 리팩토링
- [ ] 빌드 부분 혹은 패키지 매니저 수정
- [ ] 파일 혹은 폴더명 수정
- [ ] 파일 혹은 폴더 삭제

### PR 체크리스트

<!-- PR이 다음 요구 사항을 충족하는지 확인하세요. -->

- [x] 커밋 메시지 컨벤션에 맞게 작성했습니다.
- [x] 변경 사항에 대한 테스트를 했습니다.(버그 수정/기능에 대한 테스트).

### 🔎 작업 내용

- 일기 리스트가 길어지면, 일기 리스트만 스크롤할 수 있도록 수정했음

  <br />

### 구현 이미지
![image](https://github.com/user-attachments/assets/bff40401-6663-4c14-821d-656d4c9b213c)


### 이슈

resolves #285
