### PR TITLE
feat: 페이지 이동 시 스크롤 위치 상단으로 고정하기 위한 ScrollToTop 훅 추가

### DIFF
--- a/src/hooks/index.js
+++ b/src/hooks/index.js
@@ -9,3 +9,4 @@ export { default as useBlocker } from './useBlocker.jsx';
 export { default as useDiaryActions } from './useDiaryActions';
 export { default as useSearchDiary } from './useSearchDiary.js';
 export { default as useNotification } from './useNotification.js';
+export { default as ScrollToTop } from './useScrollToTop.jsx';

--- a/src/hooks/useScrollToTop.jsx
+++ b/src/hooks/useScrollToTop.jsx
@@ -1,0 +1,14 @@
+import { useEffect } from 'react';
+import { useLocation } from 'react-router-dom';
+
+const useScrollToTop = () => {
+  const { pathname } = useLocation();
+
+  useEffect(() => {
+    window.scrollTo(0, 0);
+  }, [pathname]);
+
+  return null;
+};
+
+export default useScrollToTop;

--- a/src/layouts/RootLayout.jsx
+++ b/src/layouts/RootLayout.jsx
@@ -1,7 +1,10 @@
 import { Footer } from '@/components';
+import { ScrollToTop } from '@/hooks';
 import { Outlet } from 'react-router-dom';
 
 function RootLayout() {
+  ScrollToTop();
+
   return (
     <>
       <Outlet />


### PR DESCRIPTION
### 제목 : feat: 페이지 이동 시 스크롤 위치 상단으로 고정하기 위한 ScrollToTop 훅 추가

### PR 유형

- [x] 새로운 기능 추가
- [ ] 버그 수정
- [ ] CSS 등 사용자 UI 디자인 변경
- [ ] 코드에 영향을 주지 않는 변경사항(오타 수정, 탭 사이즈 변경, 변수명 변경)
- [ ] 코드 리팩토링
- [ ] 주석 추가 및 수정
- [ ] 문서 수정
- [ ] 테스트 추가, 테스트 리팩토링
- [ ] 빌드 부분 혹은 패키지 매니저 수정
- [ ] 파일 혹은 폴더명 수정
- [ ] 파일 혹은 폴더 삭제

### PR 체크리스트

<!-- PR이 다음 요구 사항을 충족하는지 확인하세요. -->

- [x] 커밋 메시지 컨벤션에 맞게 작성했습니다.
- [ ] 변경 사항에 대한 테스트를 했습니다.(버그 수정/기능에 대한 테스트).

### 🔎 작업 내용

<!-- 어떤 작업을 하셨는지 상세하게 작성해주세요-->

- 페이지 이동 시 스크롤 위치 상단으로 고정하기 위한 ScrollToTop 훅 추가
  <br />


### 이슈

<!-- 이슈 키워드와 함께 #을 입력한 후 이슈 번호를 선택해주세요. -->
<!-- 예시 : resolves #1 -->

resolves #195 
