### PR TITLE
bugfix : DiaryCard 컴포넌트 timeAgo 속성 isRequired 삭제

### DIFF
--- a/src/components/common/DiaryCard.jsx
+++ b/src/components/common/DiaryCard.jsx
@@ -201,7 +201,7 @@ DiaryCard.propTypes = {
   type: PropTypes.oneOf(['icons', 'date']),
   onDelete: PropTypes.func,
   exchange: PropTypes.bool,
-  timeAgo: PropTypes.string.isRequired,
+  timeAgo: PropTypes.string,
 };
 
 export default memo(DiaryCard);


### PR DESCRIPTION
resolves #305

### 제목 : 
bugfix : DiaryCard 컴포넌트 timeAgo 속성 isRequired 삭제

### PR 유형

- [ ] 새로운 기능 추가
- [x] 버그 수정
- [ ] CSS 등 사용자 UI 디자인 변경
- [ ] 코드에 영향을 주지 않는 변경사항(오타 수정, 탭 사이즈 변경, 변수명 변경)
- [ ] 코드 리팩토링
- [ ] 주석 추가 및 수정
- [ ] 문서 수정
- [ ] 테스트 추가, 테스트 리팩토링
- [ ] 빌드 부분 혹은 패키지 매니저 수정
- [ ] 파일 혹은 폴더명 수정
- [ ] 파일 혹은 폴더 삭제

### PR 체크리스트

<!-- PR이 다음 요구 사항을 충족하는지 확인하세요. -->

- [x] 커밋 메시지 컨벤션에 맞게 작성했습니다.
- [ ] 변경 사항에 대한 테스트를 했습니다.(버그 수정/기능에 대한 테스트).

### 🔎 작업 내용

DiaryCard 컴포넌트 timeAgo 속성 isRequired 삭제
  <br />

### 이슈
resolves #305
