### PR TITLE
design: 일기 검색 결과에서 DiaryCard 사이 간격 조정

### DIFF
--- a/src/components/searchdiary/SearchDiaryResult.jsx
+++ b/src/components/searchdiary/SearchDiaryResult.jsx
@@ -11,14 +11,12 @@ const SearchDiaryResult = ({
 
   if (Object.keys(searchResults).length > 0 && inputValue) {
     return (
-      <main className="flex flex-col">
+      <main>
         {Object.keys(searchResults).map((yearMonth) => (
-          <section key={yearMonth} className="my-5">
-            <h2 className="font-semibold text-left text-gray-450">
-              {yearMonth}
-            </h2>
+          <section key={yearMonth} className="flex flex-col">
+            <h2 className="mt-5 font-semibold text-left">{yearMonth}</h2>
             {searchResults[yearMonth].map((diary) => (
-              <div key={diary.id} className="">
+              <div key={diary.id} className="mb-5">
                 <DiaryCard diary={diary} buddyData={buddyData} />
               </div>
             ))}


### PR DESCRIPTION
### 제목 : design: 일기 검색 결과에서 DiaryCard 사이 간격 조정

### PR 유형

- [ ] 새로운 기능 추가
- [ ] 버그 수정
- [x] CSS 등 사용자 UI 디자인 변경
- [ ] 코드에 영향을 주지 않는 변경사항(오타 수정, 탭 사이즈 변경, 변수명 변경)
- [ ] 코드 리팩토링
- [ ] 주석 추가 및 수정
- [ ] 문서 수정
- [ ] 테스트 추가, 테스트 리팩토링
- [ ] 빌드 부분 혹은 패키지 매니저 수정
- [ ] 파일 혹은 폴더명 수정
- [ ] 파일 혹은 폴더 삭제

### PR 체크리스트

<!-- PR이 다음 요구 사항을 충족하는지 확인하세요. -->

- [x] 커밋 메시지 컨벤션에 맞게 작성했습니다.
- [ ] 변경 사항에 대한 테스트를 했습니다.(버그 수정/기능에 대한 테스트).

### 🔎 작업 내용

<!-- 어떤 작업을 하셨는지 상세하게 작성해주세요-->

- 일기 검색 결과에서 DiaryCard 사이 margin 값 수정
- 🔍
   - gap-5 section태그에서 `flex flex-col gap-5 `로 gap을 추가할 경우
![image](https://github.com/user-attachments/assets/bd30f8ba-1918-419d-a3d5-47de4e2927ab)
날짜와 DiaryCard간 의 gap도 포함되어 너무 넓어짐 

   - gap으로 조정하지않고 mt, mb으로 간격 조정함 
![image](https://github.com/user-attachments/assets/1a53ac7a-0013-425c-acb6-4ba7c9895ead)


  <br />

### 🔧 앞으로의 과제

- 내일 할 일을 적어주세요
  <br />

### 이슈

<!-- 이슈 키워드와 함께 #을 입력한 후 이슈 번호를 선택해주세요. -->
<!-- 에시 : resolves #1 -->

resolves #304 
