### PR TITLE
modify : 상세다이어리 '교환하기' 버튼 & 알림페이지 모달창 '교환' 수락 버튼 비동기 진행중인 경우 비활성화

### DIFF
--- a/src/components/common/BuddyListModal.jsx
+++ b/src/components/common/BuddyListModal.jsx
@@ -1,5 +1,7 @@
 import PropTypes from 'prop-types';
 import { Modal, CheckBox } from '..';
+import { useState } from 'react';
+import toast from 'react-hot-toast';
 
 const BuddyListModal = ({
   isOpen,
@@ -9,6 +11,21 @@ const BuddyListModal = ({
   handleChange,
   handleExchange,
 }) => {
+  const [isSubmitting, setIsSubmitting] = useState(false);
+
+  const handleSubmit = async () => {
+    if (isSubmitting) return;
+
+    setIsSubmitting(true);
+    try {
+      await handleExchange();
+    } catch (error) {
+      console.error('[error] 교환일기 신청 실패: ', error);
+      toast.error('교환일기 신청에 실패했습니다. ');
+    }
+    setIsSubmitting(false);
+  };
+
   return (
     <Modal isOpen={isOpen} closeModal={closeModal}>
       <div className="flex flex-col gap-4">
@@ -28,12 +45,16 @@ const BuddyListModal = ({
         ))}
         <button
           type="button"
-          className="py-2 font-medium text-white rounded-md bg-blue"
-          onClick={handleExchange}
-          disabled={buddyData.length === 0}
-          aria-disabled={buddyData.length === 0}
+          className={`${
+            buddyData.length === 0 || isSubmitting
+              ? 'bg-gray-300'
+              : 'bg-blue-500'
+          } py-2 font-medium text-white rounded-md bg-blue`}
+          onClick={handleSubmit}
+          disabled={buddyData.length === 0 || isSubmitting}
+          aria-disabled={buddyData.length === 0 || isSubmitting}
         >
-          교환신청
+          {isSubmitting ? '교환 신청 중...' : '교환신청'}
         </button>
       </div>
     </Modal>

--- a/src/pages/Notification.jsx
+++ b/src/pages/Notification.jsx
@@ -20,6 +20,7 @@ const Notification = () => {
   const [checkedIndex, setCheckedIndex] = useState(null);
   const [diary, setDiary] = useState('');
   const [selectedNotification, setSelectedNotification] = useState(null);
+  const [isSubmitting, setIsSubmitting] = useState(false);
 
   const { isOpen, openModal, closeModal } = useModal();
   const { diaryData } = useFetchAllDiaryData();
@@ -58,6 +59,9 @@ const Notification = () => {
   };
 
   const handleDiaryExchange = async () => {
+    if (isSubmitting) return;
+
+    setIsSubmitting(true);
     const data = {
       recipient_diary: diary,
       status: 'accepted',
@@ -75,6 +79,7 @@ const Notification = () => {
       console.error('[error] 교환일기 수락 실패: ', error);
       toast.error('교환일기 수락에 실패했습니다.');
     }
+    setIsSubmitting(false);
   };
 
   const handleBuddyAccept = async (notification) => {
@@ -131,7 +136,6 @@ const Notification = () => {
     return <p>{errorMessage}</p>;
   }
 
-  // 데이터가 로드되고 알림이 있을 때 알림 목록을 렌더링
   return (
     <>
       <section className="flex flex-col gap-5 min-h-dvh pb-[80px]">
@@ -175,21 +179,30 @@ const Notification = () => {
         <div className="flex flex-col gap-4 max-h-[50vh]">
           <h2 className="text-lg font-semibold text-gray-500">일기 리스트</h2>
           <div className="flex flex-col gap-2 overflow-y-auto">
-            {diaryData.map((diary, idx) => (
-              <CheckBox
-                key={diary.id}
-                label={diary.date}
-                checked={checkedIndex === idx}
-                onChange={() => handleChange(diary.id, idx)}
-              />
-            ))}
+            {diaryData.length === 0 ? (
+              <div className="p-4 font-medium text-center text-gray-400">
+                교환할 수 있는 일기가 없어요 😥
+              </div>
+            ) : (
+              diaryData.map((diary, idx) => (
+                <CheckBox
+                  key={diary.id}
+                  label={diary.date}
+                  checked={checkedIndex === idx}
+                  onChange={() => handleChange(diary.id, idx)}
+                />
+              ))
+            )}
           </div>
           <button
             type="button"
-            className="py-2 font-medium text-white rounded-md bg-blue"
+            className={`py-2 font-medium text-white rounded-md ${
+              diaryData.length === 0 || isSubmitting ? 'bg-gray-300' : 'bg-blue'
+            }`}
             onClick={handleDiaryExchange}
+            disabled={diaryData.length === 0 || isSubmitting}
           >
-            교환
+            {isSubmitting ? '교환 중...' : '교환'}
           </button>
         </div>
       </Modal>


### PR DESCRIPTION
### 제목 : feat(issue 번호): 
modify : 상세다이어리 '교환하기' 버튼 & 알림페이지 모달창 '교환' 수락 버튼 비동기 진행중인 경우 비활성화

### PR 유형

- [x] 새로운 기능 추가
- [ ] 버그 수정
- [x] CSS 등 사용자 UI 디자인 변경
- [ ] 코드에 영향을 주지 않는 변경사항(오타 수정, 탭 사이즈 변경, 변수명 변경)
- [ ] 코드 리팩토링
- [ ] 주석 추가 및 수정
- [ ] 문서 수정
- [ ] 테스트 추가, 테스트 리팩토링
- [ ] 빌드 부분 혹은 패키지 매니저 수정
- [ ] 파일 혹은 폴더명 수정
- [ ] 파일 혹은 폴더 삭제

### PR 체크리스트

<!-- PR이 다음 요구 사항을 충족하는지 확인하세요. -->

- [x] 커밋 메시지 컨벤션에 맞게 작성했습니다.
- [x] 변경 사항에 대한 테스트를 했습니다.(버그 수정/기능에 대한 테스트).

### 🔎 작업 내용

- 상세다이어리 '교환하기 버튼' -> 비동기 진행중인 경우 비활성화
- 알림페이지 모달창 '교환' 수락 버튼 -> 비동기 진행중인 경우 비활성화
- 알림페이지 교환 수락 모달창 -> 저장된 일기가 없는 경우 '교환' 버튼 비활성화 및 안내 글귀 추가
  <br />

### 구현 이미지
1) 다이어리 상세 페이지
![image](https://github.com/user-attachments/assets/e0577e5b-5ea2-4de3-97d7-dbd0eb3ff446)
2) 알림페이지 -> 교환 일기 카드  모달창
![image](https://github.com/user-attachments/assets/63c4edb2-d333-46f8-b1b6-5c1a26b99157)
3) 알림페이지 -> 저장된 일기가 없는 경우
![638623654386010404](https://github.com/user-attachments/assets/aaa7a902-3a6e-47ef-8338-9876e244ef14)

### 이슈

resolves #307
