### PR TITLE
refactor: 일기 작성에서 한줄일기 글자 제한 부분 마크업 / 로직 수정

### DIFF
--- a/src/components/newdiary/TextArea.jsx
+++ b/src/components/newdiary/TextArea.jsx
@@ -1,16 +1,20 @@
-import { useRef, useEffect } from 'react';
 import PropTypes from 'prop-types';
+import { useEffect, useRef } from 'react';
 
 const TextArea = ({ text, setText }) => {
   const textarea = useRef(null);
+  const maxLength = 200;
+
+  const textAreaClasses =
+    text.length == maxLength ? 'text-blue-500 font-semibold' : '';
 
   const onChange = (e) => {
     const value = e.target.value;
-    if (textarea.current.scrollHeight >= 184) {
-      alert('최대 6줄까지 작성을 할 수 있습니다.');
-      return;
+    if (value.trim() === '') {
+      setText('');
+    } else {
+      setText(value);
     }
-    setText(value);
   };
 
   useEffect(() => {
@@ -20,14 +24,19 @@ const TextArea = ({ text, setText }) => {
 
   return (
     <div className="flex flex-col gap-[0.9375rem] w-full px-5 py-[0.9375rem] bg-white rounded-[0.94rem] shadow-light">
-      <span className="text-base font-semibold text-gray-450">한줄일기</span>
+      <div className="flex justify-between w-full">
+        <span className="text-base font-semibold text-gray-450">한줄일기</span>
+        <span className="text-sm text-gray-400">
+          <span className={textAreaClasses}>{text.length}</span> / {maxLength}
+        </span>
+      </div>
       <textarea
         ref={textarea}
         value={text}
         onChange={onChange}
-        className="w-full min-h-[50px] max-h-[232px] p-2 border border-blue-100 bg-blue-10 rounded-[0.375rem] resize-none content-center placeholder:text-blue-500 text-blue-500 outline-none focus:border-blue-500"
+        className="w-full min-h-[50px] max-h-[232px] p-3 border border-blue-100 bg-blue-10 rounded-[0.375rem] resize-none content-center placeholder:text-blue-300 text-blue-500 outline-none focus:border-blue-500"
         placeholder="일기를 작성해주세요."
-        maxLength="200"
+        maxLength={maxLength}
         rows={1}
       />
     </div>


### PR DESCRIPTION
### 제목 : refactor: 일기 작성에서 한줄일기 글자 제한 부분 마크업 / 스타일링 수정


### PR 유형

- [ ] 새로운 기능 추가
- [ ] 버그 수정
- [x] CSS 등 사용자 UI 디자인 변경
- [ ] 코드에 영향을 주지 않는 변경사항(오타 수정, 탭 사이즈 변경, 변수명 변경)
- [x] 코드 리팩토링
- [ ] 주석 추가 및 수정
- [ ] 문서 수정
- [ ] 테스트 추가, 테스트 리팩토링
- [ ] 빌드 부분 혹은 패키지 매니저 수정
- [ ] 파일 혹은 폴더명 수정
- [ ] 파일 혹은 폴더 삭제

### PR 체크리스트

<!-- PR이 다음 요구 사항을 충족하는지 확인하세요. -->

- [x] 커밋 메시지 컨벤션에 맞게 작성했습니다.
- [ ] 변경 사항에 대한 테스트를 했습니다.(버그 수정/기능에 대한 테스트).

### 🔎 작업 내용

<!-- 어떤 작업을 하셨는지 상세하게 작성해주세요-->

- 200자 제한 글자 수를 (현재 글자 수 / 200) 형식으로 텍스트 입력 영역 아래에 표시하도록 마크업/스타일링 수정
- 일기 작성 시, 스페이스바만 눌러서 (혹은 공백인 부분을 복사 붙여넣기) 공백 입력 후 작성하면 신규 글이 작성이 가능해지는 현상 발견하여, 공백만 입력했을 경우에는 setText('') 처리하여 아무 공백도 입력되지 못하게 처리함
  <br />


### 이슈

<!-- 이슈 키워드와 함께 #을 입력한 후 이슈 번호를 선택해주세요. -->
<!-- 에시 : resolves #1 -->

resolves #310 