### PR TITLE
bugfix : 닉네임 변경 시 유효성 검사 기능 추가 및 스타일링 수정

### DIFF
--- a/src/pages/mypage/MyPageSetting.jsx
+++ b/src/pages/mypage/MyPageSetting.jsx
@@ -150,7 +150,9 @@ const MypageSetting = () => {
 
     navigate('/login');
 
-    toast.success('회원탈퇴가 성공적으로 처리되었습니다.');
+    toast.success('회원탈퇴가 성공적으로 처리되었습니다.', {
+      duration: 2000,
+    });
   }, [navigate]);
 
   return (


### PR DESCRIPTION
### 제목 : 
bugfix : 닉네임 변경 시 유효성 검사 기능 추가 및 스타일링 수정

### PR 유형

- [x] 새로운 기능 추가
- [ ] 버그 수정
- [x] CSS 등 사용자 UI 디자인 변경
- [ ] 코드에 영향을 주지 않는 변경사항(오타 수정, 탭 사이즈 변경, 변수명 변경)
- [ ] 코드 리팩토링
- [ ] 주석 추가 및 수정
- [ ] 문서 수정
- [ ] 테스트 추가, 테스트 리팩토링
- [ ] 빌드 부분 혹은 패키지 매니저 수정
- [ ] 파일 혹은 폴더명 수정
- [ ] 파일 혹은 폴더 삭제

### PR 체크리스트

<!-- PR이 다음 요구 사항을 충족하는지 확인하세요. -->

- [x] 커밋 메시지 컨벤션에 맞게 작성했습니다.
- [x] 변경 사항에 대한 테스트를 했습니다.(버그 수정/기능에 대한 테스트).

### 🔎 작업 내용

- 유효성 검사 통과 x -> 변경 버튼 비활성화
- 이전에는 '닉네임 변경' 버튼 비활성화 시, 버튼 색상을 gray로 바꿨는데, 유효성 검사의 경우까지 포함할 경우 닉네임 인풋을 수정할 때마다 버튼 색상이 바뀌는 게 너무 난잡한 것 같아서 '닉네임 변경' 버튼의 색상은 blue로 고정하고, '중복검사' 버튼만 유효성 검사 & 중복검사 통과한 경우에 색상 변경하는 걸로 수정했음
- myPageSetting 모든 토스트 메시지 듀레이션 2초로 수정
  <br />

### 구현이미지
1) 유효성 검사 통과 x -> 닉네임 변경 버튼 비활성화
![image](https://github.com/user-attachments/assets/da602e5d-ed2b-4008-ac3e-538c47317828)

2) 닉네임 중복 검사 통과 x -> 닉네임 변경 버튼 비활성화
![image](https://github.com/user-attachments/assets/6d0f2b22-0cff-4a37-bbfd-616fe89deb8c)

3) 모두 통과 -> 닉네임 변경 버튼 활성화, 중복검사 버튼 비활성화
![image](https://github.com/user-attachments/assets/83b3b039-7b98-46f2-a512-d3b48d0007b6)



### 이슈

resolves #316
