### PR TITLE
bugfix: 단짝 관계 절교 시 교환일기 관련 알림 및 일기 데이터 삭제 처리

### DIFF
--- a/src/components/buddy/BuddyCard.jsx
+++ b/src/components/buddy/BuddyCard.jsx
@@ -1,26 +1,82 @@
-import { PropTypes } from 'prop-types';
-import { differenceInDays, differenceInHours } from 'date-fns';
-import { memo } from 'react';
 import pb from '@/api/pb';
+import { useModal } from '@/hooks';
+import { differenceInDays, differenceInHours } from 'date-fns';
+import { PropTypes } from 'prop-types';
+import { memo } from 'react';
 import toast from 'react-hot-toast';
 import { ConfirmModal } from '..';
-import { useModal } from '@/hooks';
+import { authUtils } from '@/utils';
+import { useNotificationStore } from '@/stores';
 
 const BuddyCard = ({ buddyName, startDate, buddyId, onDelete }) => {
   const hoursDifference = differenceInHours(new Date(), new Date(startDate));
   const daysDifference = differenceInDays(new Date(), new Date(startDate));
+  const setNotifications = useNotificationStore(
+    (state) => state.setNotifications
+  );
 
   const { isOpen, openModal, closeModal } = useModal();
 
   const handleDelete = async () => {
     try {
-      const userId = JSON.parse(localStorage.getItem('auth')).user.id;
+      const { user } = authUtils.getAuth();
+      const userId = user.id;
 
-      const records = await pb.collection('buddy').getFullList({
-        filter: `recipient = "${buddyId}" && requester = "${userId}" || recipient = "${userId}" && requester = "${buddyId}"`,
+      if (!user) {
+        toast.error(
+          '사용자 인증정보를 불러오지 못했어요. 다시 시도해주세요 😥'
+        );
+        return;
+      }
+
+      const record = await pb
+        .collection('buddy')
+        .getFirstListItem(
+          `recipient = "${buddyId}" && requester = "${userId}" || recipient = "${userId}" && requester = "${buddyId}"`
+        );
+
+      if (!record) {
+        toast.error('단짝 정보를 찾을 수 없어요. 다시 시도해주세요 😥');
+        return;
+      }
+
+      await pb.collection('buddy').delete(record.id);
+
+      // 교환일기 알림 삭제
+      const notification = await pb
+        .collection('notification')
+        .getFirstListItem(
+          `(recipient = "${userId}" && requester = "${buddyId}" && type = "교환일기") || (recipient = "${buddyId}" && requester = "${userId}" && type = "교환일기")`
+        );
+
+      if (notification) {
+        await pb.collection('notification').delete(notification.id);
+      }
+
+      // 교환일기 삭제
+      const posts = await pb.collection('post').getFullList({
+        filter: `(recipient = "${buddyId}" && requester = "${userId}") || (recipient = "${userId}" && requester = "${buddyId}")`,
       });
 
-      await pb.collection('buddy').delete(records[0].id);
+      if (posts.length > 0) {
+        for (const post of posts) {
+          await pb.collection('post').delete(post.id);
+        }
+      }
+
+      // 알림 상태 업데이트
+      const updatedNotifications = await pb
+        .collection('notification')
+        .getFullList({
+          filter: `recipient = "${userId}"`,
+        });
+      setNotifications(
+        updatedNotifications.map((list) => ({
+          ...list,
+          read: false,
+        }))
+      );
+
       toast.success('단짝을 멀리 보냈습니다.');
       closeModal('breachModal');
       onDelete(buddyId);

--- a/src/hooks/useNotification.js
+++ b/src/hooks/useNotification.js
@@ -79,6 +79,9 @@ const useNotification = () => {
           read: false,
         });
       }
+      if (e.action === 'delete') {
+        fetchNotifications();
+      }
     };
 
     fetchNotifications();


### PR DESCRIPTION
### 제목 : bugfix: 단짝 관계 절교 시 교환일기 관련 알림 및 일기 데이터 삭제 처리

- [ ] 새로운 기능 추가
- [x] 버그 수정
- [ ] CSS 등 사용자 UI 디자인 변경
- [ ] 코드에 영향을 주지 않는 변경사항(오타 수정, 탭 사이즈 변경, 변수명 변경)
- [ ] 코드 리팩토링
- [ ] 주석 추가 및 수정
- [ ] 문서 수정
- [ ] 테스트 추가, 테스트 리팩토링
- [ ] 빌드 부분 혹은 패키지 매니저 수정
- [ ] 파일 혹은 폴더명 수정
- [ ] 파일 혹은 폴더 삭제

### PR 체크리스트

<!-- PR이 다음 요구 사항을 충족하는지 확인하세요. -->

- [x] 커밋 메시지 컨벤션에 맞게 작성했습니다.
- [ ] 변경 사항에 대한 테스트를 했습니다.(버그 수정/기능에 대한 테스트).

### 🔎 작업 내용

<!-- 어떤 작업을 하셨는지 상세하게 작성해주세요-->

- 교환일기 신청 후 단짝 절교 시 알림 및 일기가 삭제되지 않는 문제 해결
- 단짝 관계가 해제되면 관련 교환일기 알림과 일기를 삭제하도록 수정
- 알림 상태를 최신 상태로 업데이트하고, 실시간으로 알림 배지가 제대로 작동하도록 처리
  <br />


### 🔧 앞으로의 과제
```
      const updatedNotifications = await pb
        .collection('notification')
        .getFullList({
          filter: `recipient = "${userId}"`,
        });
      setNotifications(
        updatedNotifications.map((list) => ({
          ...list,
          read: false,
        }))
```
- 버그 수정 후 작동은 잘 되지만, 알림 상태 업데이트 하는 부분에서 알림 삭제 후 전체 리스트를 다시 불러오는 방식이
비효율 적일 수 있다는 gpt 답변을 보고 해당 로직을 수정하려고 하였으나, 수정 중 이 부분에서 계속 오류가 났습니다 😭
(useNotificationStore 에서 getNotifications 을 사용하여 알림 리스트 가져오려 시도)

다른 이슈 진행을 위하여 일단 이후 최적화 진행 할 경우 이 부분 염두에 두고 처리 하도록 하겠습니당.


  <br />
  
### 이슈

<!-- 이슈 키워드와 함께 #을 입력한 후 이슈 번호를 선택해주세요. -->
<!-- 에시 : resolves #1 -->

resolves #315 
