### PR TITLE
bugfix: 일기 교환 로직 중 교환 버튼 활성화 조건 수정

### DIFF
--- a/src/pages/Notification.jsx
+++ b/src/pages/Notification.jsx
@@ -197,10 +197,10 @@ const Notification = () => {
           <button
             type="button"
             className={`py-2 font-medium text-white rounded-md ${
-              diaryData.length === 0 || isSubmitting ? 'bg-gray-300' : 'bg-blue'
+              !diary || isSubmitting ? 'bg-gray-300' : 'bg-blue'
             }`}
             onClick={handleDiaryExchange}
-            disabled={diaryData.length === 0 || isSubmitting}
+            disabled={!diary || isSubmitting}
           >
             {isSubmitting ? '교환 중...' : '교환'}
           </button>


### PR DESCRIPTION
### 제목 : bugfix: 일기 교환 로직 중 교환 버튼 활성화 조건 수정

### PR 유형

- [ ] 새로운 기능 추가
- [x] 버그 수정
- [ ] CSS 등 사용자 UI 디자인 변경
- [ ] 코드에 영향을 주지 않는 변경사항(오타 수정, 탭 사이즈 변경, 변수명 변경)
- [ ] 코드 리팩토링
- [ ] 주석 추가 및 수정
- [ ] 문서 수정
- [ ] 테스트 추가, 테스트 리팩토링
- [ ] 빌드 부분 혹은 패키지 매니저 수정
- [ ] 파일 혹은 폴더명 수정
- [ ] 파일 혹은 폴더 삭제

### PR 체크리스트

<!-- PR이 다음 요구 사항을 충족하는지 확인하세요. -->

- [x] 커밋 메시지 컨벤션에 맞게 작성했습니다.
- [ ] 변경 사항에 대한 테스트를 했습니다.(버그 수정/기능에 대한 테스트).

### 🔎 작업 내용

<!-- 어떤 작업을 하셨는지 상세하게 작성해주세요-->

- 기존 코드에서 diaryData.length === 0 조건으로는 일기가 목록에 존재만 한다면 버튼이 활성화 되고 교환이 되어버리는 문제가 생김
- !diary 조건으로 수정하여 선택한 일기가 있을 경우에 버튼 활성화 여부 결정하도록 수정
  <br />

### 이슈

<!-- 이슈 키워드와 함께 #을 입력한 후 이슈 번호를 선택해주세요. -->
<!-- 에시 : resolves #1 -->

resolves #324 
