### PR TITLE
bugfix : 단짝 사이에 동일한 일기가 중복 교환되는 에러 수정 완료

### DIFF
--- a/src/pages/Notification.jsx
+++ b/src/pages/Notification.jsx
@@ -62,23 +62,52 @@ const Notification = () => {
     if (isSubmitting) return;
 
     setIsSubmitting(true);
-    const data = {
-      recipient_diary: diary,
-      status: 'accepted',
-    };
+
     try {
+      // 1. post 컬렉션에서 교환된 기록이 있는지 확인
+      const existingExchanges = await pb.collection('post').getFullList({
+        filter: `
+          (
+            (recipient = "${selectedNotification.requester}" && requester = "${userId}") || 
+            (recipient = "${userId}" && requester = "${selectedNotification.requester}")
+          ) && 
+          (
+            recipient_diary = "${diary}" || 
+            requester_diary = "${diary}"
+          )
+        `,
+      });
+
+      // 중복된 일기가 있는 경우 교환 못함
+      if (existingExchanges.length > 0) {
+        toast.error('이미 해당 단짝과 이 일기를 교환 중입니다.', {
+          id: 'preventExchangeDiaryDuplicationOnNotification',
+          duration: 2000,
+        });
+        setIsSubmitting(false);
+        return;
+      }
+
+      // 2. 중복되지 않은 경우 교환 수락 처리
+      const data = {
+        recipient_diary: diary,
+        status: 'accepted',
+      };
+
       await pb.collection('post').update(selectedNotification.type_id, data);
       await pb.collection('notification').delete(selectedNotification.id);
 
       setNotificationData((prevData) =>
         prevData.filter((item) => item.id !== selectedNotification.id)
       );
-      toast.success('교환일기 신청이 수락 되었습니다.');
+
+      toast.success('교환일기 신청이 수락되었습니다.');
       closeModal('diaryListModal');
     } catch (error) {
       console.error('[error] 교환일기 수락 실패: ', error);
       toast.error('교환일기 수락에 실패했습니다.');
     }
+
     setIsSubmitting(false);
   };
 


### PR DESCRIPTION
resolves #332

### 제목 : 
bugfix : 단짝 사이에 동일한 일기가 중복 교환되는 에러 수정 완료

### PR 유형

- [ ] 새로운 기능 추가
- [x] 버그 수정
- [ ] CSS 등 사용자 UI 디자인 변경
- [ ] 코드에 영향을 주지 않는 변경사항(오타 수정, 탭 사이즈 변경, 변수명 변경)
- [ ] 코드 리팩토링
- [ ] 주석 추가 및 수정
- [ ] 문서 수정
- [ ] 테스트 추가, 테스트 리팩토링
- [ ] 빌드 부분 혹은 패키지 매니저 수정
- [ ] 파일 혹은 폴더명 수정
- [ ] 파일 혹은 폴더 삭제

### PR 체크리스트

<!-- PR이 다음 요구 사항을 충족하는지 확인하세요. -->

- [x] 커밋 메시지 컨벤션에 맞게 작성했습니다.
- [ ] 변경 사항에 대한 테스트를 했습니다.(버그 수정/기능에 대한 테스트).

### 🔎 작업 내용

- 다이어리 상세페이지에서 교환하는 경우와 알림 페이지에서 교환 요청을 수락하는 경우 -> existingExchange 변수로 기존에 이미 같은 일기로 교환된 기록이 있는지 확인 후 toast.error 띄우기

  <br />

### 구현이미지
* 다이어리 상세페이지에서 교환요청 하는 경우
![image](https://github.com/user-attachments/assets/e41164ee-be47-40cc-858f-93bc138d12bf)

* 알림 페이지에서 교환 요청 수락하는 경우
![image](https://github.com/user-attachments/assets/75938495-2965-4d9b-bd77-8ba4ce5e4fad)

  <br />

### 이슈

resolves #332
